### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something in the boilerplate doesn't work as expected
+title: "[Bug] "
+labels: bug
+---
+
+## What happened
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you thought would happen. -->
+
+## Environment
+
+- Roku model:
+- Roku OS version:
+- VSCode + BrightScript extension version:
+- OS (macOS / Windows / Linux):
+
+## Logs / screenshots
+
+<!-- Paste any relevant telnet output, errors, or screenshots. -->
+
+## Additional context
+
+<!-- Anything else worth knowing — recent changes you made, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an addition or change to the boilerplate
+title: "[Feature] "
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this solve? Who benefits? -->
+
+## Proposed solution
+
+<!-- How would it work? What does the API/UX look like? -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about and why you didn't pick them. -->
+
+## Additional context
+
+<!-- Roku platform constraints, links to related work, mockups, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Testing
+
+- Roku model tested on:
+- Roku OS version:
+- What you exercised manually:
+
+## Screenshots / logs
+
+<!-- For UI changes or behavioral fixes. Optional otherwise. -->
+
+## Checklist
+
+- [ ] README updated if behavior or setup changed
+- [ ] `manifest` version bumped if appropriate
+- [ ] No `_` line-continuations introduced in BrightScript
+- [ ] Tested on a real device (not just compiled)

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ roku-boilerplate.code-workspace
 !/.gitignore
 !/.vscode
 !/.env-sample
+!/.github


### PR DESCRIPTION
## Summary

Adds structured templates so future issues and PRs come in with the info needed to triage them.

- `.github/ISSUE_TEMPLATE/bug_report.md` — prompts for Roku model + OS version, repro steps, logs
- `.github/ISSUE_TEMPLATE/feature_request.md` — prompts for problem, proposed solution, alternatives
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues so reporters have to pick a template
- `.github/PULL_REQUEST_TEMPLATE.md` — prompts contributors for what device/OS they tested on

## Why now

Issue #7 (a vague "Hello plz help" with no detail) sat open for ~2 years. Templates make that less likely.

## Notes

Also whitelisted `.github/` in `.gitignore` — the repo otherwise ignores all dotfiles via `.*`, so the new directory wouldn't have been tracked.