### PR TITLE
Fix six runtime bugs in dialog, screen, and message handling

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -62,6 +62,13 @@ end sub
 sub onMessage(obj)
 	' get the message string
 	message = obj.getData()
-	' check that the message string is not invalid and not empty then create message dialog
-	if message <> invalid and len(message) > 0 then createDialog(getMessage(message))
+	if (message <> invalid and len(message) > 0)
+		' guard against an unknown key so the dialog code isn't called with invalid
+		params = getMessage(message)
+		if (params <> invalid)
+			createDialog(params)
+		else
+			? "no message found for key: " + message + " - HomeScene.brs"
+		end if
+	end if
 end sub

--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -65,8 +65,6 @@ sub onButtonChange(obj)
         childNodes = m.buttonarea.getChildren(-1, 0)
         ' remove all child nodes from inside the button area node
         m.buttonarea.removeChildren(childNodes)
-        ' reset the button node array
-        m.bulletarea.bulletText = []
     end if
     ' check that the new button array is not invalid and is not an empty array
     if (buttons <> invalid and buttons.count() > 0)

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -31,7 +31,7 @@ sub populateDialogBox(obj)
         ' inspect the dialog info message
         if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0 then message = m.dialogInfo.message else message = ""
         ' inspect the dialog info help message
-        if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0 then help = m.dialogInfo.bulletText else help = []
+        if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0 then help = m.dialogInfo.help else help = []
         ' inspect the dialog info buttons
         if m.dialogInfo.buttons <> invalid and m.dialogInfo.buttons.count() > 0 then buttons = m.dialogInfo.buttons else buttons = []
         ' create the dialog node

--- a/components/utils/Messages.brs
+++ b/components/utils/Messages.brs
@@ -36,7 +36,6 @@ function getMessage(messageString = "" as string)
 			for each message in json.items()
 				if (message.key = messageString and message.value <> invalid)
 					return message.value
-					exit for
 				end if
 			end for
 		end if

--- a/components/utils/Requirements.brs
+++ b/components/utils/Requirements.brs
@@ -16,6 +16,8 @@ function createRequirements() as object
 	return invalid
 end function
 function checkRequirements(requirements as object) as boolean
+	' default to ready so empty or all-optional requirement sets pass the type contract
+	deviceReady = true
 	for each requirement in requirements.items()
 		if (requirement.value <> invalid and requirement.value["required"])
 			deviceReady = getRequirement(requirement)
@@ -58,7 +60,6 @@ function getModel(requirement as object, model as string) as boolean
 	for each legacyModel in requirement.value["legacyModels"]
 		if (model = legacyModel)
 			return false
-			exit for
 		end if
 	end for
 	return true

--- a/components/utils/Screens.brs
+++ b/components/utils/Screens.brs
@@ -45,8 +45,8 @@ function addScreen(screenName as string, screenId = invalid as string, showScree
     if screenExists(screenId)
         ? " "
         ? "The id '" + screenId + "' is already assigned to another screen node. Please create a new id for this node."
-        ' assign an empty string to the screenId
-        screenId = ""
+        ' refuse to add a duplicate; callers already null-check the return
+        return invalid
     end if
     return m.top.getScene().callFunc("addNode", {"screenName": screenName, "showScreen": showScreen, "screenId": screenId, "hidePrevScreen": hidePrevScreen, "addToStack": addToStack})
 end function


### PR DESCRIPTION
## Summary

Six surgical bug fixes uncovered during a full read-through of the codebase. No new features, no refactoring — each change is the minimum diff needed to make existing behavior correct.

## Bugs

### B1 · Bullet text never displayed in dialogs
[`DialogModal.brs:34`](../blob/fix/runtime-bugs/components/screens/dialogs/DialogModal.brs#L34) — `populateDialogBox` *checked* `m.dialogInfo.help` but *assigned from* `m.dialogInfo.bulletText` (a key that doesn't exist in `messages.json`). The help bullets in the internet / OS / model / HDCP / exit dialogs never rendered.

### B2 · `addScreen` could create duplicate screens
[`Screens.brs:48`](../blob/fix/runtime-bugs/components/utils/Screens.brs#L48) — when a duplicate screen id was detected, the function blanked the id and *fell through* to `callFunc("addNode", ...)`. `addNode` then defaulted the empty id back to `screenName`, producing the very duplicate the check was meant to prevent. Now returns `invalid` on duplicate. Already-correct callers (`Messages.brs:13`) null-check the return value.

### B3 · `checkRequirements` returned `invalid` instead of boolean
[`Requirements.brs:18`](../blob/fix/runtime-bugs/components/utils/Requirements.brs#L18) — `deviceReady` was only assigned inside the `if (required)` branch. With an empty or all-optional requirements set, it was never assigned and the function returned `invalid` despite an `as boolean` signature. Now initialized to `true` at function entry.

### B4 · Stale `bulletText` reset on button change
[`BaseDialog.brs:69`](../blob/fix/runtime-bugs/components/screens/dialogs/BaseDialog.brs#L69) — `onButtonChange` was clearing `m.bulletarea.bulletText`, almost certainly a copy/paste from `onBulletTextChange`. Whenever buttons changed (e.g., on a new dialog with the same modal screen), bullet text disappeared.

### B5 · `onMessage` didn't handle unknown keys
[`HomeScene.brs:62-66`](../blob/fix/runtime-bugs/components/HomeScene.brs#L62-L74) — `getMessage(messageString)` returns `invalid` when the key isn't found in `messages.json`. The result was passed straight to `createDialog` with no check. `createDialog` happens to guard against `invalid`, so this didn't crash — but the user got silence instead of a logged error. Now guards explicitly and logs the missing key.

### B6 · Dead `exit for` after `return`
[`Messages.brs:39`](../blob/fix/runtime-bugs/components/utils/Messages.brs) and [`Requirements.brs:61`](../blob/fix/runtime-bugs/components/utils/Requirements.brs) — both had `return X` immediately followed by `exit for`. The `exit for` was unreachable. Removed.

## Testing

Visual inspection only — no test framework in the repo yet (a separate PR will tackle that later). Each fix is small, localized, and was reasoned through against the call graph + JSON data.

## Out of scope

- Pyramid-of-doom flattening / guard clauses
- Mixed tab/space indentation across files
- `BaseScreen` becoming a real abstraction
- Const-ifying magic strings ("OKAY", "back", etc.)
- Caching `messages.json` instead of disk-reading per call
- The "Cannot find function" diagnostics from the BrightScript Language Extension — those are pre-existing static-analysis limitations of cross-XML script visibility, not real runtime errors.

These each warrant their own focused PRs and were noted during the audit.