### PR TITLE
Refactor BaseScreen into a real abstraction with lifecycle hooks

### DIFF
--- a/components/screens/base/BaseScreen.brs
+++ b/components/screens/base/BaseScreen.brs
@@ -1,2 +1,16 @@
 sub init()
+    ' hide until shown; subclasses override the hooks below, not init()
+    m.top.visible = false
+    m.top.observeField("visible", "baseScreenOnVisibleChange")
+    onScreenInit()
+end sub
+sub baseScreenOnVisibleChange(obj)
+    if obj.getData() then onScreenVisible() else onScreenHidden()
+end sub
+' default no-op hooks; subclasses override by redeclaring
+sub onScreenInit()
+end sub
+sub onScreenVisible()
+end sub
+sub onScreenHidden()
 end sub

--- a/components/screens/base/BaseScreen.xml
+++ b/components/screens/base/BaseScreen.xml
@@ -7,6 +7,9 @@
 	<script type="text/brightscript" uri="pkg:/components/utils/History.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/Themes.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/General.brs" />
+	<interface>
+		<field id="focusedNode" type="node" />
+	</interface>
 	<children>
 	</children>
 </component>

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -1,7 +1,3 @@
-sub init()
-    ' set the initial visibility of the screen to false
-    m.top.visible = false
-end sub
 sub createDialogNode(title = "" as string, message = "" as string, help = [] as object, buttons = [] as object)
     ' create message dialog node
     m.dialogNode = CreateObject("roSGNode", "BaseDialog")

--- a/components/screens/landing/LandingScreen.brs
+++ b/components/screens/landing/LandingScreen.brs
@@ -1,31 +1,15 @@
-sub init()
-    ' set the initial visibility of the screen to false
-    m.top.visible = false
-    ' ### node identifiers ###
-    ' identify the label list
+sub onScreenInit()
     m.labelList = m.top.findNode("landingLabelList")
-    ' identify the title label
     m.landingTitle = m.top.findNode("landingTitle")
-    ' ### node observers ###
-    ' observe screen visibility
-    m.top.observeField("visible", "screenVisible")
-    ' observe button presses on the label list
     m.labelList.observeField("itemSelected", "onItemSelected")
 end sub
-sub screenVisible(obj)
-    visible = obj.getData()
-    if (visible)
-        ' set text and theme of landing title
-        setLandingTitle()
-        ' populate the label list with content
-        populateLabelList()
-        ' set location and theme of label list
-        setLabelList()
-        ' set key focus to the label list
-        setFocus(m.labelList)
-        ' send signal beacon per Roku certification requirements
-        appLoaded()
-    end if
+sub onScreenVisible()
+    setLandingTitle()
+    populateLabelList()
+    setLabelList()
+    setFocus(m.labelList)
+    ' Roku certification requires this beacon to indicate app finished loading
+    appLoaded()
 end sub
 sub setLandingTitle()
     ' set the text string for the title label - tr() is optional for translating the string to another language


### PR DESCRIPTION
## Summary

Turns `BaseScreen` from a no-op placeholder (1-line `sub init()`) into a real base class with declared interface fields and three lifecycle hooks. Subclasses (`LandingScreen`, `DialogModal`) drop their init boilerplate and override the hooks instead.

Net: **-29 lines, +26 lines**, but the meaningful read is in what subclasses look like — significantly tighter.

## What changes

### `BaseScreen.xml`
- Adds `<field id="focusedNode" type="node"/>` to the interface. [`Screens.brs:121`](../blob/refactor/basescreen-lifecycle/components/utils/Screens.brs#L121) was inventing this field on the fly via `update(..., createFields=true)`. The contract is now explicit in XML.

### `BaseScreen.brs`
Was:
```
sub init()
end sub
```
Now owns the common screen lifecycle:
- `m.top.visible = false` (every subclass was duplicating this)
- `m.top.observeField("visible", "baseScreenOnVisibleChange")`
- Calls `onScreenInit()`
- The visibility observer dispatches to `onScreenVisible()` or `onScreenHidden()` based on the new value.

All three hooks have no-op defaults declared in BaseScreen.brs. Subclasses override by *redeclaring* the function (SceneGraph loads parent scripts before child scripts, so the child's definition wins).

### `LandingScreen.brs`
- `init()` → `onScreenInit()` — dropped the manual `m.top.visible = false` and the manual `m.top.observeField("visible", ...)`, since BaseScreen owns both.
- `screenVisible(obj)` → `onScreenVisible()` — dropped the `if (visible)` check, since the dispatcher only fires this hook *when* the screen becomes visible.
- Also stripped a bunch of what-the-next-line-does comments (kept the certification beacon comment because it explains *why*).

### `DialogModal.brs`
- Removed `init()` entirely. The only thing it did was `m.top.visible = false`, which BaseScreen now handles. Dialog content flow is still driven by the `dialogInfo` `onChange` observer; that's a node-data flow, not a lifecycle event.

## What does *not* change

- `HomeScene` extends `Scene` (not `BaseScreen`), so it's untouched.
- No util script reshuffling. No new files. No new dependencies.
- All public behavior is identical from a viewer-of-the-channel perspective.

## Why this is the right abstraction for SceneGraph

SceneGraph doesn't give you `super.init()` — if a subclass defines `init()`, it fully replaces the parent's. The lifecycle-hook pattern is the standard workaround: parent owns `init()`, parent calls hooks, subclass overrides hooks. Same shape as iOS UIKit's `viewWillAppear` / Android's `onResume`. Future contributors writing a new screen now just:

```
sub onScreenInit()
    ' set up node references and field observers
end sub
sub onScreenVisible()
    ' do work that requires the screen to be on-screen
end sub
```

…and never touch `init()` directly.

## Testing

Visual review against the call graph. Key flow checks:
- Screen creation: `addNode` (HomeScene.brs:26) → `createObject` → BaseScreen.init() runs → visible=false → observer attached → `onScreenInit()` called → then `addHistory` sets visible=true → observer fires → `onScreenVisible()` called. Order is correct.
- Screen removal: `removeHistory` (History.brs:49) sets visible=false → observer fires → `onScreenHidden()` (no-op for current screens, safe). Then node is removed.