### PR TITLE
Normalize leading indentation to 4 spaces

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -1,74 +1,74 @@
 sub init()
-	' change to true for testing themes set in /components/data/themes.json
-	' the setTheme() has a 2nd argument for defining the theme ex. setTheme(true, { "type": "light", "color": "red" })
-	' ensure that both the "type" and "color" inside the object match the key/values in themes.json
-	setTheme(true)
-	' set to true for forcing requirements in /components/data/requirements.json
-	' set to false to immediately return true and bypass requirements
-	' optional: test the error message for requirements by changing the minVersion in the requirements.json file from to 20.0
-	requirements = setRequirements(false)
-	' start the app if all requirements are met
-	if requirements then startApp()
+    ' change to true for testing themes set in /components/data/themes.json
+    ' the setTheme() has a 2nd argument for defining the theme ex. setTheme(true, { "type": "light", "color": "red" })
+    ' ensure that both the "type" and "color" inside the object match the key/values in themes.json
+    setTheme(true)
+    ' set to true for forcing requirements in /components/data/requirements.json
+    ' set to false to immediately return true and bypass requirements
+    ' optional: test the error message for requirements by changing the minVersion in the requirements.json file from to 20.0
+    requirements = setRequirements(false)
+    ' start the app if all requirements are met
+    if requirements then startApp()
 end sub
 sub startApp()
-	' create the initial screen stack array in History.brs
-	initScreenStack()
-	' create the landing screen node (name) and assign an id
-	' see REAMDME for additional arguments
-	addScreen("LandingScreen", "landingScreen")
+    ' create the initial screen stack array in History.brs
+    initScreenStack()
+    ' create the landing screen node (name) and assign an id
+    ' see REAMDME for additional arguments
+    addScreen("LandingScreen", "landingScreen")
 end sub
 function addNode(params as object) as object
-	' check that the object from params is valid
-	if (params <> invalid and params.count() > 0)
-		' check that the screenName value in the object is valid
-		if (params.screenName <> invalid and len(params.screenName) > 0)
-			' create the node using the params.screen value
-			node = createObject("roSGNode", params.screenName)
-			' check that the created node is valid
-			if (node <> invalid)
-				' check if the node ID is not yet assigned
-				if (node.id = invalid or (node.id <> invalid and len(node.id) = 0))
-					' check if the screenId is valid and has a string length greater than zero
-					if (params.screenId <> invalid and len(params.screenId) > 0)
-						' assign the node ID using params.screenId
-						node.id = params.screenId
-					else
-						' assign the node ID usind params.screenName
-						node.id = params.screenName
-					end if
-				end if
-				' add the screen to History.brs
-				if (not addHistory(node, params.showScreen, params.hidePrevScreen, params.addToStack))
-					' show a console message stating that the node could not be added to HomeScene
-					? " "
-					? "there was an error adding " + node.id + " to HomeScene"
-				else
-					' set focus to node
-					node.setFocus(true)
-				end if
-				' return the node
-				return node
-			end if
-		end if
-	end if
+    ' check that the object from params is valid
+    if (params <> invalid and params.count() > 0)
+        ' check that the screenName value in the object is valid
+        if (params.screenName <> invalid and len(params.screenName) > 0)
+            ' create the node using the params.screen value
+            node = createObject("roSGNode", params.screenName)
+            ' check that the created node is valid
+            if (node <> invalid)
+                ' check if the node ID is not yet assigned
+                if (node.id = invalid or (node.id <> invalid and len(node.id) = 0))
+                    ' check if the screenId is valid and has a string length greater than zero
+                    if (params.screenId <> invalid and len(params.screenId) > 0)
+                        ' assign the node ID using params.screenId
+                        node.id = params.screenId
+                    else
+                        ' assign the node ID usind params.screenName
+                        node.id = params.screenName
+                    end if
+                end if
+                ' add the screen to History.brs
+                if (not addHistory(node, params.showScreen, params.hidePrevScreen, params.addToStack))
+                    ' show a console message stating that the node could not be added to HomeScene
+                    ? " "
+                    ? "there was an error adding " + node.id + " to HomeScene"
+                else
+                    ' set focus to node
+                    node.setFocus(true)
+                end if
+                ' return the node
+                return node
+            end if
+        end if
+    end if
 end function
 sub removeNode(params as object)
-	if (not removeHistory(params.node, params.showPrevScreen, params.removeFromStack))
-		' show a console message stating that the node could not be added to HomeScene
-		? " "
-		? "there was an error removing the node from HomeScene"
-	end if
+    if (not removeHistory(params.node, params.showPrevScreen, params.removeFromStack))
+        ' show a console message stating that the node could not be added to HomeScene
+        ? " "
+        ? "there was an error removing the node from HomeScene"
+    end if
 end sub
 sub onMessage(obj)
-	' get the message string
-	message = obj.getData()
-	if (message <> invalid and len(message) > 0)
-		' guard against an unknown key so the dialog code isn't called with invalid
-		params = getMessage(message)
-		if (params <> invalid)
-			createDialog(params)
-		else
-			? "no message found for key: " + message + " - HomeScene.brs"
-		end if
-	end if
+    ' get the message string
+    message = obj.getData()
+    if (message <> invalid and len(message) > 0)
+        ' guard against an unknown key so the dialog code isn't called with invalid
+        params = getMessage(message)
+        if (params <> invalid)
+            createDialog(params)
+        else
+            ? "no message found for key: " + message + " - HomeScene.brs"
+        end if
+    end if
 end sub

--- a/components/utils/General.brs
+++ b/components/utils/General.brs
@@ -11,6 +11,6 @@ sub appLoaded(node = m.top.getScene())
         ' indicate that the app is now loaded
         node.appLoaded = true
         ' Roku certification requires this to indicate the app is finished loading
-	    node.signalBeacon("AppLaunchComplete")
+        node.signalBeacon("AppLaunchComplete")
     end if
 end sub

--- a/components/utils/Messages.brs
+++ b/components/utils/Messages.brs
@@ -1,48 +1,48 @@
 sub createDialog(params = {} as object)
-	if (params <> invalid)
-		if (params.count() > 0)
-			if (params.title <> invalid and len(params.title) > 0)
-				messageValid = true
-			else
-				messageValid = false
-				? "message title is required - Messages.brs"
-				? "message is: "; params
-			end if
-			if (messageValid <> invalid and messageValid)
-				if not screenExists("dialogModal")
-					screen = addScreen("DialogModal", "dialogModal", true, false)
-				else
-					screen = getScreen("dialogModal")
-				end if
-				if (screen <> invalid)
-					showDialog(params, screen)
-				end if
-			end if
-		else
-			? "message is empty - Messages.brs"
-		end if
-	else
-		? "message is not an object - Messages.brs"
-	end if
+    if (params <> invalid)
+        if (params.count() > 0)
+            if (params.title <> invalid and len(params.title) > 0)
+                messageValid = true
+            else
+                messageValid = false
+                ? "message title is required - Messages.brs"
+                ? "message is: "; params
+            end if
+            if (messageValid <> invalid and messageValid)
+                if not screenExists("dialogModal")
+                    screen = addScreen("DialogModal", "dialogModal", true, false)
+                else
+                    screen = getScreen("dialogModal")
+                end if
+                if (screen <> invalid)
+                    showDialog(params, screen)
+                end if
+            end if
+        else
+            ? "message is empty - Messages.brs"
+        end if
+    else
+        ? "message is not an object - Messages.brs"
+    end if
 end sub
 sub showDialog(params as object, screen as object)
-	screen.dialogInfo = params
+    screen.dialogInfo = params
 end sub
 function getMessage(messageString = "" as string)
-	messagefile = ReadAsciiFile("pkg:/components/data/messages.json")
-	if (messagefile <> invalid)
-		json = ParseJson(messagefile)
-		if (json <> invalid)
-			for each message in json.items()
-				if (message.key = messageString and message.value <> invalid)
-					return message.value
-				end if
-			end for
-		end if
-	else
-		return invalid
-	end if
+    messagefile = ReadAsciiFile("pkg:/components/data/messages.json")
+    if (messagefile <> invalid)
+        json = ParseJson(messagefile)
+        if (json <> invalid)
+            for each message in json.items()
+                if (message.key = messageString and message.value <> invalid)
+                    return message.value
+                end if
+            end for
+        end if
+    else
+        return invalid
+    end if
 end function
 sub setMessage(message as string)
-	m.top.getScene().message = message
+    m.top.getScene().message = message
 end sub

--- a/components/utils/Requirements.brs
+++ b/components/utils/Requirements.brs
@@ -1,66 +1,66 @@
 function setRequirements(params as boolean) as boolean
-	requirements = createRequirements()
-	if (params and requirements <> invalid)
-		return checkRequirements(requirements)
-	end if
-	return true
+    requirements = createRequirements()
+    if (params and requirements <> invalid)
+        return checkRequirements(requirements)
+    end if
+    return true
 end function
 function createRequirements() as object
-	requirementsFile = ReadAsciiFile("pkg:/components/data/requirements.json")
-	if (requirementsFile <> invalid)
-		json = ParseJson(requirementsFile)
-		if (json <> invalid)
-			return json
-		end if
-	end if
-	return invalid
+    requirementsFile = ReadAsciiFile("pkg:/components/data/requirements.json")
+    if (requirementsFile <> invalid)
+        json = ParseJson(requirementsFile)
+        if (json <> invalid)
+            return json
+        end if
+    end if
+    return invalid
 end function
 function checkRequirements(requirements as object) as boolean
-	' default to ready so empty or all-optional requirement sets pass the type contract
-	deviceReady = true
-	for each requirement in requirements.items()
-		if (requirement.value <> invalid and requirement.value["required"])
-			deviceReady = getRequirement(requirement)
-			if (deviceReady <> invalid)
-				if (not deviceReady and requirement.value["showError"] <> invalid and requirement.value["showError"])
-					m.top.getScene().message = requirement.key
-					exit for
-				end if
-			else
-				deviceReady = true
-			end if
-		end if
-	end for
-	return deviceReady
+    ' default to ready so empty or all-optional requirement sets pass the type contract
+    deviceReady = true
+    for each requirement in requirements.items()
+        if (requirement.value <> invalid and requirement.value["required"])
+            deviceReady = getRequirement(requirement)
+            if (deviceReady <> invalid)
+                if (not deviceReady and requirement.value["showError"] <> invalid and requirement.value["showError"])
+                    m.top.getScene().message = requirement.key
+                    exit for
+                end if
+            else
+                deviceReady = true
+            end if
+        end if
+    end for
+    return deviceReady
 end function
 function getRequirement(requirement as object) as boolean
-	v = m.global[requirement.key]
-	if (v = invalid)
-		return false
-	else if (type(v) = "roBoolean")
-		return v
-	else
-		return setAsBool(requirement, v)
-	end if
+    v = m.global[requirement.key]
+    if (v = invalid)
+        return false
+    else if (type(v) = "roBoolean")
+        return v
+    else
+        return setAsBool(requirement, v)
+    end if
 end function
 function setAsBool(requirement as object, v as dynamic)
-	if (requirement.key = "os")
-		return getMinOS(requirement, v)
-	else if (requirement.key = "model")
-		return getModel(requirement, v)
-	end if
+    if (requirement.key = "os")
+        return getMinOS(requirement, v)
+    else if (requirement.key = "model")
+        return getModel(requirement, v)
+    end if
 end function
 function getMinOS(requirement as object, os as float) as boolean
-	if (os >= requirement.value["minVersion"])
-		return true
-	end if
-	return false
+    if (os >= requirement.value["minVersion"])
+        return true
+    end if
+    return false
 end function
 function getModel(requirement as object, model as string) as boolean
-	for each legacyModel in requirement.value["legacyModels"]
-		if (model = legacyModel)
-			return false
-		end if
-	end for
-	return true
+    for each legacyModel in requirement.value["legacyModels"]
+        if (model = legacyModel)
+            return false
+        end if
+    end for
+    return true
 end function

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -1,194 +1,194 @@
 sub main(args)
-	'######################### DEVELOPER VARIABLES ##########################
-	showDeviceInfo = false ' show device info in the console
-	showAppInfo = false ' show app info in the console
-	showBandwidth = false ' show bandwidth utilization
-	showHttpErrors = false ' show http and url errors
-	'########################################################################
+    '######################### DEVELOPER VARIABLES ##########################
+    showDeviceInfo = false ' show device info in the console
+    showAppInfo = false ' show app info in the console
+    showBandwidth = false ' show bandwidth utilization
+    showHttpErrors = false ' show http and url errors
+    '########################################################################
 
-	'########################### DEVICE/APP INFO ############################
-	' create device info object
-	deviceInfo = setDeviceInfo()
-	' create app/manifest info object
-	appInfo = setAppInfo()
-	' print device info to console
-	if showDeviceInfo then getDeviceInfo(deviceInfo)
-	' print app info to console
-	if showAppInfo then getAppInfo(appInfo)
-	'########################################################################
+    '########################### DEVICE/APP INFO ############################
+    ' create device info object
+    deviceInfo = setDeviceInfo()
+    ' create app/manifest info object
+    appInfo = setAppInfo()
+    ' print device info to console
+    if showDeviceInfo then getDeviceInfo(deviceInfo)
+    ' print app info to console
+    if showAppInfo then getAppInfo(appInfo)
+    '########################################################################
 
-	'########################## SCENEGRAPH SETUP ############################
-	' create message event listener
-	port = createObject("roMessagePort")
-	' create root scenegraph node
-	screen = createObject("roSGScreen")
-	' set global values using info obtained from device and app
-	setGlobals(screen, deviceInfo, appInfo, args)
-	' set the message port for screen events
-	screen.setMessagePort(port)
-	' create the initial scenegraph object
-	scene = screen.createScene("HomeScene")
-	' render the initial scenegraph object
-	screen.show()
-	' observe changes to exitApp interface on HomeScene
-	scene.observeField("exitApp", port)
-	'########################################################################
+    '########################## SCENEGRAPH SETUP ############################
+    ' create message event listener
+    port = createObject("roMessagePort")
+    ' create root scenegraph node
+    screen = createObject("roSGScreen")
+    ' set global values using info obtained from device and app
+    setGlobals(screen, deviceInfo, appInfo, args)
+    ' set the message port for screen events
+    screen.setMessagePort(port)
+    ' create the initial scenegraph object
+    scene = screen.createScene("HomeScene")
+    ' render the initial scenegraph object
+    screen.show()
+    ' observe changes to exitApp interface on HomeScene
+    scene.observeField("exitApp", port)
+    '########################################################################
 
-	'########################## LOG SYSTEM EVENTS ###########################
-	' create system logging events
-	syslog = CreateObject("roSystemLog")
-	' set the message port for logging events
-	syslog.setMessagePort(port)
-	' enable http error logging
-	syslog.EnableType("http.error")
-	' enable bandwidth measurement logging
-	syslog.EnableType("bandwidth.minute")
-	'########################################################################
+    '########################## LOG SYSTEM EVENTS ###########################
+    ' create system logging events
+    syslog = CreateObject("roSystemLog")
+    ' set the message port for logging events
+    syslog.setMessagePort(port)
+    ' enable http error logging
+    syslog.EnableType("http.error")
+    ' enable bandwidth measurement logging
+    syslog.EnableType("bandwidth.minute")
+    '########################################################################
 
-	'################### START APP AND LISTEN FOR EVENTS ####################
-	' create loop to track opening and closing of app
-	while(true)
-		' wait indefinitely
-		msg = wait(0, port)
-		' get message type
-		msgType = type(msg)
-		' check exitApp field on HomeScene - closes app (ends while loop) when set to true
-		if (scene.exitApp)
-			' exit app / end while loop
-			return
-		end if
-		' check if the message type is logging event and if developer variables are true
-		if (msgType = "roSystemLogEvent" and (showHttpErrors or showBandwidth))
-			' Handle the roSystemLogEvents:
-			i = msg.GetInfo()
-			if (i.LogType = "http.error" and showHttpErrors)
-				? "HTTP error: "; i.HttpCode
-				? "Status error: "; i.Status
-				? "URL error: "; i.origUrl
-				? "IP: "; i.TargetIp
-				? " "
-			else if (i.LogType = "bandwidth.minute" and showBandwidth)
-				bandwidth = i.Bandwidth / 1000
-				? "Bandwidth: "; bandwidth.toStr() + " Mbps"
-				? " "
-			end if
-		end if
-	end while
-	'########################################################################
+    '################### START APP AND LISTEN FOR EVENTS ####################
+    ' create loop to track opening and closing of app
+    while(true)
+        ' wait indefinitely
+        msg = wait(0, port)
+        ' get message type
+        msgType = type(msg)
+        ' check exitApp field on HomeScene - closes app (ends while loop) when set to true
+        if (scene.exitApp)
+            ' exit app / end while loop
+            return
+        end if
+        ' check if the message type is logging event and if developer variables are true
+        if (msgType = "roSystemLogEvent" and (showHttpErrors or showBandwidth))
+            ' Handle the roSystemLogEvents:
+            i = msg.GetInfo()
+            if (i.LogType = "http.error" and showHttpErrors)
+                ? "HTTP error: "; i.HttpCode
+                ? "Status error: "; i.Status
+                ? "URL error: "; i.origUrl
+                ? "IP: "; i.TargetIp
+                ? " "
+            else if (i.LogType = "bandwidth.minute" and showBandwidth)
+                bandwidth = i.Bandwidth / 1000
+                ? "Bandwidth: "; bandwidth.toStr() + " Mbps"
+                ? " "
+            end if
+        end if
+    end while
+    '########################################################################
 end sub
 function setDeviceInfo()
-	' create device info object
-	deviceInfo = createObject("roDeviceInfo")
-	' create HDMI info object
-	hdmiInfo = createObject("roHdmiStatus")
-	' check for an active version of hdcp or a device type of "TV" - all others refer to a set top box
-	if len(hdmiInfo.getHdcpVersion()) > 0 or deviceInfo.getModelType() = "TV" then hdcpStatus = true else hdcpStatus = false
-	' get OS version
-	os = deviceInfo.getOSVersion().major + "." + deviceInfo.getOSVersion().minor
-	' determine if device will return internet status
-	internetStatus = findMemberFunction(deviceInfo, "getInternetStatus")
-	if (internetStatus <> invalid)
-		' required minimum OS version 10.0
-		internet = deviceInfo.getInternetStatus()
-	else
-		internet = deviceInfo.getLinkStatus()
-	end if
-	device = {
-		"id": deviceInfo.GetChannelClientId(),
-		"model": deviceInfo.getModel(),
-		"type": deviceInfo.getModelType(),
-		"os": os.toFloat(),
-		"language": deviceInfo.getCurrentLocale(),
-		"graphics": deviceInfo.getGraphicsPlatform(),
-		"display": {
-			"name": deviceInfo.getModelDisplayName(),
-			"type": deviceInfo.GetDisplayType(),
-			"ui": {
-				"width": deviceInfo.getUIResolution().width,
-				"height": deviceInfo.getUIResolution().height,
-				"name": deviceInfo.getUIResolution().name
-			},
-			"video": deviceInfo.getVideoMode()
-		},
-		"network": {
-			"internet": internet,
-			"type": deviceInfo.getConnectionType(),
-			"externalIP": deviceInfo.getExternalIp()
-		},
-		"hdmi": {
-			"connected": hdmiInfo.isConnected(),
-			"hdcp": hdcpStatus
-		}
-	}
-	return device
+    ' create device info object
+    deviceInfo = createObject("roDeviceInfo")
+    ' create HDMI info object
+    hdmiInfo = createObject("roHdmiStatus")
+    ' check for an active version of hdcp or a device type of "TV" - all others refer to a set top box
+    if len(hdmiInfo.getHdcpVersion()) > 0 or deviceInfo.getModelType() = "TV" then hdcpStatus = true else hdcpStatus = false
+    ' get OS version
+    os = deviceInfo.getOSVersion().major + "." + deviceInfo.getOSVersion().minor
+    ' determine if device will return internet status
+    internetStatus = findMemberFunction(deviceInfo, "getInternetStatus")
+    if (internetStatus <> invalid)
+        ' required minimum OS version 10.0
+        internet = deviceInfo.getInternetStatus()
+    else
+        internet = deviceInfo.getLinkStatus()
+    end if
+    device = {
+        "id": deviceInfo.GetChannelClientId(),
+        "model": deviceInfo.getModel(),
+        "type": deviceInfo.getModelType(),
+        "os": os.toFloat(),
+        "language": deviceInfo.getCurrentLocale(),
+        "graphics": deviceInfo.getGraphicsPlatform(),
+        "display": {
+            "name": deviceInfo.getModelDisplayName(),
+            "type": deviceInfo.GetDisplayType(),
+            "ui": {
+                "width": deviceInfo.getUIResolution().width,
+                "height": deviceInfo.getUIResolution().height,
+                "name": deviceInfo.getUIResolution().name
+            },
+            "video": deviceInfo.getVideoMode()
+        },
+        "network": {
+            "internet": internet,
+            "type": deviceInfo.getConnectionType(),
+            "externalIP": deviceInfo.getExternalIp()
+        },
+        "hdmi": {
+            "connected": hdmiInfo.isConnected(),
+            "hdcp": hdcpStatus
+        }
+    }
+    return device
 end function
 function setAppInfo()
-	appInfo = createObject("roAppInfo")
+    appInfo = createObject("roAppInfo")
 
-	app = {
-		"id": appInfo.getID(),
-		"isDev": appInfo.isDev(),
-		"devId": appInfo.getDevID(),
-		"title": appInfo.getTitle(),
-		"version": appInfo.getVersion()
-	}
-	return app
+    app = {
+        "id": appInfo.getID(),
+        "isDev": appInfo.isDev(),
+        "devId": appInfo.getDevID(),
+        "title": appInfo.getTitle(),
+        "version": appInfo.getVersion()
+    }
+    return app
 end function
 sub getDeviceInfo(deviceInfo)
-	' show information about device
-	? "- - - - - - - - - - - - - - - - - - -"
-	? "Model:            "; deviceInfo.model
-	? "Type:             "; deviceInfo.type
-	? "OS Version:      "; deviceInfo.os
-	? "Language:         "; deviceInfo.language
-	? "Graphics:         "; deviceInfo.graphics
-	? "Display Name:     "; deviceInfo.display.name
-	? "Display Type:     "; deviceInfo.display.type
-	? "UI Resolution:    "; deviceInfo.display.ui.name
-	? "Video Mode:       "; deviceInfo.display.video
-	? "Internet Status:  "; deviceInfo.network.internet
-	? "Connection Type:  "; deviceInfo.network.type
-	? "External IP:      "; deviceInfo.network.externalIP
-	? "HDMI Status:      "; deviceInfo.hdmi.connected
-	? "HDCP Valid:       "; deviceInfo.hdmi.hdcp
-	? "- - - - - - - - - - - - - - - - - - -"
-	? " "
+    ' show information about device
+    ? "- - - - - - - - - - - - - - - - - - -"
+    ? "Model:            "; deviceInfo.model
+    ? "Type:             "; deviceInfo.type
+    ? "OS Version:      "; deviceInfo.os
+    ? "Language:         "; deviceInfo.language
+    ? "Graphics:         "; deviceInfo.graphics
+    ? "Display Name:     "; deviceInfo.display.name
+    ? "Display Type:     "; deviceInfo.display.type
+    ? "UI Resolution:    "; deviceInfo.display.ui.name
+    ? "Video Mode:       "; deviceInfo.display.video
+    ? "Internet Status:  "; deviceInfo.network.internet
+    ? "Connection Type:  "; deviceInfo.network.type
+    ? "External IP:      "; deviceInfo.network.externalIP
+    ? "HDMI Status:      "; deviceInfo.hdmi.connected
+    ? "HDCP Valid:       "; deviceInfo.hdmi.hdcp
+    ? "- - - - - - - - - - - - - - - - - - -"
+    ? " "
 end sub
 sub getAppInfo(appInfo)
-	' show information about app
-	? "- - - - - - - - - - - - - - - - - - -"
-	? "App ID:           "; appInfo.id
-	? "Is Dev:           "; appInfo.isDev
-	? "Dev ID:           "; appInfo.devId
-	? "Title:            "; appInfo.title
-	? "Version:          "; appInfo.version
-	? "- - - - - - - - - - - - - - - - - - -"
-	? " "
+    ' show information about app
+    ? "- - - - - - - - - - - - - - - - - - -"
+    ? "App ID:           "; appInfo.id
+    ? "Is Dev:           "; appInfo.isDev
+    ? "Dev ID:           "; appInfo.devId
+    ? "Title:            "; appInfo.title
+    ? "Version:          "; appInfo.version
+    ? "- - - - - - - - - - - - - - - - - - -"
+    ? " "
 end sub
 sub setGlobals(screen, deviceInfo, appInfo, deepLinkArgs)
-	' get the global reference object
-	m.global = screen.getGlobalNode()
-	' assign variables to global object
-	m.global.addFields({
-		"deviceId": deviceInfo.id,
-		"model": deviceInfo.model,
-		"os": deviceInfo.os,
-		"internet": deviceInfo.network.internet,
-		"language": deviceInfo.language,
-		"graphics": deviceInfo.graphics,
-		"ui": deviceInfo.display.ui,
-		"hdcp": deviceInfo.hdmi.hdcp,
-		"deeplink": getDeepLinks(deepLinkArgs)
-	})
+    ' get the global reference object
+    m.global = screen.getGlobalNode()
+    ' assign variables to global object
+    m.global.addFields({
+        "deviceId": deviceInfo.id,
+        "model": deviceInfo.model,
+        "os": deviceInfo.os,
+        "internet": deviceInfo.network.internet,
+        "language": deviceInfo.language,
+        "graphics": deviceInfo.graphics,
+        "ui": deviceInfo.display.ui,
+        "hdcp": deviceInfo.hdmi.hdcp,
+        "deeplink": getDeepLinks(deepLinkArgs)
+    })
 end sub
 function getDeepLinks(args) as object
-	deeplink = invalid
-	' check if both contentId and mediaType are valid
-	if (args.contentId <> invalid and args.mediaType <> invalid)
-		deeplink = {
-			id: args.contentId
-			type: args.mediaType
-		}
-	end if
-	return deeplink
+    deeplink = invalid
+    ' check if both contentId and mediaType are valid
+    if (args.contentId <> invalid and args.mediaType <> invalid)
+        deeplink = {
+            id: args.contentId
+            type: args.mediaType
+        }
+    end if
+    return deeplink
 end function


### PR DESCRIPTION
## Summary

Whitespace-only PR. Converts leading tabs to 4 spaces in the 5 `.brs` files that still used tabs:

- `source/Main.brs`
- `components/HomeScene.brs`
- `components/utils/General.brs`
- `components/utils/Messages.brs`
- `components/utils/Requirements.brs`

The other 7 `.brs` files in the repo already used 4 spaces, so this aligns everything on the majority style.

## Verification

```
$ git diff -w --stat
(empty)
```

No content change. Reviewers can use `?w=1` on GitHub's diff URL or `git diff -w` locally to confirm.

## Why now

Prerequisite for the next PR (guard-clause flattening). Doing the indent change first keeps each diff readable on its own — otherwise the logic refactor's diff would be dominated by indent shifts on every touched line.

## Out of scope

- XML indentation (separate question; XML files are visually consistent enough)
- Trailing whitespace (none found)
- Newline at end of file (a couple of files lack one; intentional to keep this PR purely about leading-whitespace style)