### PR TITLE
Flatten nested guards into early returns across utility code

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -18,39 +18,24 @@ sub startApp()
     addScreen("LandingScreen", "landingScreen")
 end sub
 function addNode(params as object) as object
-    ' check that the object from params is valid
-    if (params <> invalid and params.count() > 0)
-        ' check that the screenName value in the object is valid
-        if (params.screenName <> invalid and len(params.screenName) > 0)
-            ' create the node using the params.screen value
-            node = createObject("roSGNode", params.screenName)
-            ' check that the created node is valid
-            if (node <> invalid)
-                ' check if the node ID is not yet assigned
-                if (node.id = invalid or (node.id <> invalid and len(node.id) = 0))
-                    ' check if the screenId is valid and has a string length greater than zero
-                    if (params.screenId <> invalid and len(params.screenId) > 0)
-                        ' assign the node ID using params.screenId
-                        node.id = params.screenId
-                    else
-                        ' assign the node ID usind params.screenName
-                        node.id = params.screenName
-                    end if
-                end if
-                ' add the screen to History.brs
-                if (not addHistory(node, params.showScreen, params.hidePrevScreen, params.addToStack))
-                    ' show a console message stating that the node could not be added to HomeScene
-                    ? " "
-                    ? "there was an error adding " + node.id + " to HomeScene"
-                else
-                    ' set focus to node
-                    node.setFocus(true)
-                end if
-                ' return the node
-                return node
-            end if
+    if params = invalid or params.count() = 0 then return invalid
+    if params.screenName = invalid or len(params.screenName) = 0 then return invalid
+    node = createObject("roSGNode", params.screenName)
+    if node = invalid then return invalid
+    if node.id = invalid or len(node.id) = 0
+        if params.screenId <> invalid and len(params.screenId) > 0
+            node.id = params.screenId
+        else
+            node.id = params.screenName
         end if
     end if
+    if addHistory(node, params.showScreen, params.hidePrevScreen, params.addToStack)
+        node.setFocus(true)
+    else
+        ? " "
+        ? "there was an error adding " + node.id + " to HomeScene"
+    end if
+    return node
 end function
 sub removeNode(params as object)
     if (not removeHistory(params.node, params.showPrevScreen, params.removeFromStack))

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -20,19 +20,12 @@ sub createDialogNode(title = "" as string, message = "" as string, help = [] as 
 end sub
 sub populateDialogBox(obj)
     m.dialogInfo = obj.getData()
-    ' check if the dialogInfo object is valid and count is greater than zero
-    if (m.dialogInfo <> invalid and m.dialogInfo.count() > 0)
-        ' inspect the dialog info title
-        if m.dialogInfo.title <> invalid and len(m.dialogInfo.title) > 0 then title = m.dialogInfo.title else title = ""
-        ' inspect the dialog info message
-        if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0 then message = m.dialogInfo.message else message = ""
-        ' inspect the dialog info help message
-        if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0 then help = m.dialogInfo.help else help = []
-        ' inspect the dialog info buttons
-        if m.dialogInfo.buttons <> invalid and m.dialogInfo.buttons.count() > 0 then buttons = m.dialogInfo.buttons else buttons = []
-        ' create the dialog node
-        createDialogNode(title, message, help, buttons)
-    end if
+    if m.dialogInfo = invalid or m.dialogInfo.count() = 0 then return
+    if m.dialogInfo.title <> invalid and len(m.dialogInfo.title) > 0 then title = m.dialogInfo.title else title = ""
+    if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0 then message = m.dialogInfo.message else message = ""
+    if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0 then help = m.dialogInfo.help else help = []
+    if m.dialogInfo.buttons <> invalid and m.dialogInfo.buttons.count() > 0 then buttons = m.dialogInfo.buttons else buttons = []
+    createDialogNode(title, message, help, buttons)
 end sub
 sub onButtonSelected(obj)
     ' get button index

--- a/components/utils/History.brs
+++ b/components/utils/History.brs
@@ -3,53 +3,31 @@ sub initScreenStack()
     m.screenStack = []
 end sub
 function addHistory(node as object, showScreen as boolean, hidePrevScreen as boolean, addToStack as boolean) as boolean
-    ' check that new node is valid
-    if (node <> invalid)
-        ' check if hidePrevScreen is both valid and true
-        if (hidePrevScreen <> invalid and hidePrevScreen)
-            ' check that the screen stack array is valid and contains items
-            if (m.screenStack <> invalid and m.screenStack.count() > 0)
-                ' get the last item in the screen stack array
-                prevNode = m.screenStack.peek()
-                ' check that the previous node is valid and hide it
-                if prevNode <> invalid then prevNode.visible = false
-            end if
-        end if
-        ' check that showScreen is valid and set the new node visibility
-        if showScreen <> invalid then node.visible = showScreen
-        ' check if addToStack is both valid and true and that screen stack array is valid before pushing node to the end of the screen stack array
-        if addToStack <> invalid and addToStack and m.screenStack <> invalid then m.screenStack.push(node)
-        ' add the new node to the end of the child nodes on HomeScene and return the result
-        return m.top.appendChild(node)
+    if node = invalid then return false
+    if hidePrevScreen <> invalid and hidePrevScreen and m.screenStack <> invalid and m.screenStack.count() > 0
+        prevNode = m.screenStack.peek()
+        if prevNode <> invalid then prevNode.visible = false
     end if
+    if showScreen <> invalid then node.visible = showScreen
+    if addToStack <> invalid and addToStack and m.screenStack <> invalid then m.screenStack.push(node)
+    return m.top.appendChild(node)
 end function
 function removeHistory(node as object, showPrevScreen as boolean, removeFromStack as boolean) as boolean
-    if (node <> invalid)
-        ' check that the screen stack array is valid and contains items
-        if (m.screenStack <> invalid and m.screenStack.count() > 0)
-            ' check if removeFromStack is both valid and true
-            if (removeFromStack <> invalid and removeFromStack)
-                ' remove the last node from the screen stack array
-                if m.screenStack.peek().isSameNode(node) then m.screenStack.pop()
-            end if
-            ' check that the screen stack array still contains items and showPrevScreen is both valid and true
-            if (m.screenStack.count() > 0 and showPrevScreen <> invalid and showPrevScreen)
-                ' set prevNode to last node in array
-                prevNode = m.screenStack.peek()
-                ' check if prevNode is valid
-                if (prevNode <> invalid)
-                    ' get the last node in the screen stack array and check for visibility before setting visibility to true
-                    if not prevNode.visible then prevNode.visible = true
-                    ' check if the previous node's focusedNode field is valid then set focus to it
-                    if prevNode.focusedNode <> invalid then prevNode.focusedNode.setFocus(true)
-                end if
+    if node = invalid then return false
+    if m.screenStack <> invalid and m.screenStack.count() > 0
+        if removeFromStack <> invalid and removeFromStack
+            if m.screenStack.peek().isSameNode(node) then m.screenStack.pop()
+        end if
+        if m.screenStack.count() > 0 and showPrevScreen <> invalid and showPrevScreen
+            prevNode = m.screenStack.peek()
+            if prevNode <> invalid
+                if not prevNode.visible then prevNode.visible = true
+                if prevNode.focusedNode <> invalid then prevNode.focusedNode.setFocus(true)
             end if
         end if
-        ' set the node visibility to false
-        if node.visible then node.visible = false
-        ' remove the node as a child of HomeScene and return the result
-        return m.top.removeChild(node)
     end if
+    if node.visible then node.visible = false
+    return m.top.removeChild(node)
 end function
 sub getHistory()
     ' check that the screen stack array is valid and contains items

--- a/components/utils/Messages.brs
+++ b/components/utils/Messages.brs
@@ -1,47 +1,36 @@
 sub createDialog(params = {} as object)
-    if (params <> invalid)
-        if (params.count() > 0)
-            if (params.title <> invalid and len(params.title) > 0)
-                messageValid = true
-            else
-                messageValid = false
-                ? "message title is required - Messages.brs"
-                ? "message is: "; params
-            end if
-            if (messageValid <> invalid and messageValid)
-                if not screenExists("dialogModal")
-                    screen = addScreen("DialogModal", "dialogModal", true, false)
-                else
-                    screen = getScreen("dialogModal")
-                end if
-                if (screen <> invalid)
-                    showDialog(params, screen)
-                end if
-            end if
-        else
-            ? "message is empty - Messages.brs"
-        end if
-    else
+    if params = invalid
         ? "message is not an object - Messages.brs"
+        return
     end if
+    if params.count() = 0
+        ? "message is empty - Messages.brs"
+        return
+    end if
+    if params.title = invalid or len(params.title) = 0
+        ? "message title is required - Messages.brs"
+        ? "message is: "; params
+        return
+    end if
+    if screenExists("dialogModal")
+        screen = getScreen("dialogModal")
+    else
+        screen = addScreen("DialogModal", "dialogModal", true, false)
+    end if
+    if screen <> invalid then showDialog(params, screen)
 end sub
 sub showDialog(params as object, screen as object)
     screen.dialogInfo = params
 end sub
 function getMessage(messageString = "" as string)
     messagefile = ReadAsciiFile("pkg:/components/data/messages.json")
-    if (messagefile <> invalid)
-        json = ParseJson(messagefile)
-        if (json <> invalid)
-            for each message in json.items()
-                if (message.key = messageString and message.value <> invalid)
-                    return message.value
-                end if
-            end for
-        end if
-    else
-        return invalid
-    end if
+    if messagefile = invalid then return invalid
+    json = ParseJson(messagefile)
+    if json = invalid then return invalid
+    for each message in json.items()
+        if message.key = messageString and message.value <> invalid then return message.value
+    end for
+    return invalid
 end function
 sub setMessage(message as string)
     m.top.getScene().message = message

--- a/components/utils/Screens.brs
+++ b/components/utils/Screens.brs
@@ -1,37 +1,25 @@
 function getScreen(screenId as string, showScreen = false as boolean)
-    ' check that the argument for screenId is valid and has a string length greater than zero
-    if (screenId <> invalid and len(screenId) > 0)
-        ' find the node
-        node = m.top.getScene().findNode(screenId)
-        ' check that the node is valid
-        if (node <> invalid)
-            ' show the node if the node is not visible and the showScreen argument is true
-            if not node.visible and showScreen then node.visible = true
-            ' return the requested node
-            return node
-        else
-            ' show a console message stating the requested screen/node is not valid
-            ? " "
-            ? screenId + " was not found"
-            return invalid
-        end if
-    else
-        ' show a console message stating that getScreen requires a valid screenId
+    if screenId = invalid or len(screenId) = 0
         ? " "
         ? "you must set a valid id (string) for screenId"
+        return invalid
     end if
+    node = m.top.getScene().findNode(screenId)
+    if node = invalid
+        ? " "
+        ? screenId + " was not found"
+        return invalid
+    end if
+    if not node.visible and showScreen then node.visible = true
+    return node
 end function
 function screenExists(screenId as string) as boolean
-    ' ensure screenId is valid and not an empty string
-    if (screenId <> invalid and len(screenId) > 0)
-        ' get the screen node
-        node = getScreen(screenId)
-        if node <> invalid then return true
-    else
+    if screenId = invalid or len(screenId) = 0
         ? " "
         ? "screen not found"
+        return false
     end if
-    return false
+    return getScreen(screenId) <> invalid
 end function
 function addScreen(screenName as string, screenId = invalid as string, showScreen = true as boolean, hidePrevScreen = true as boolean, addToStack = true as boolean) as object
     ' check if screenId is invalid or empty
@@ -51,25 +39,15 @@ function addScreen(screenName as string, screenId = invalid as string, showScree
     return m.top.getScene().callFunc("addNode", {"screenName": screenName, "showScreen": showScreen, "screenId": screenId, "hidePrevScreen": hidePrevScreen, "addToStack": addToStack})
 end function
 sub removeScreen(screen = invalid as dynamic, showPrevScreen = true as boolean, removeFromStack = true as boolean)
-    ' check that screen is valid
-    if (screen <> invalid)
-        ' set initial node value
-        node = invalid
-        ' check if the screen is a node type
-        if (type(screen) = "roSGNode")
-            ' set the node value
-            node = screen
-        ' check if the screen is a string type
-        else if (type(screen) = "String" and len(screen) > 0)
-            ' find the node and set the return valud
-            node = getScreen(screen)
-        end if
-        ' check if the node is valid
-        if (node <> invalid)
-            ' call the removeNode function on the HomeScene interface
-            m.top.getScene().callFunc("removeNode", {"node": node, "showPrevScreen": showPrevScreen, "removeFromStack": removeFromStack})
-        end if
+    if screen = invalid then return
+    node = invalid
+    if type(screen) = "roSGNode"
+        node = screen
+    else if type(screen) = "String" and len(screen) > 0
+        node = getScreen(screen)
     end if
+    if node = invalid then return
+    m.top.getScene().callFunc("removeNode", {"node": node, "showPrevScreen": showPrevScreen, "removeFromStack": removeFromStack})
 end sub
 function getAllScreens() as dynamic
     ' create a variable to store all of the child nodes from HomeScene
@@ -100,25 +78,15 @@ sub showAllScreens()
     end if
 end sub
 sub setFocus(node as dynamic, saveFocus = true as boolean)
-    ' check that node is valid
-    if (node <> invalid)
-        ' set initial focusedNode value
-        focusedNode = invalid
-        ' check if the node is a node type
-        if (type(node) = "roSGNode")
-            ' set the focusedNode value
-            focusedNode = node
-        ' check if the node is a string type
-        else if (type(node) = "String" and len(node) > 0)
-            ' find the node and set the return valud
-            focusedNode = getScreen(node)
-        end if
-        ' check if the focusedNode is valid
-        if (focusedNode <> invalid)
-            ' set focus to node
-            focusedNode.setFocus(true)
-            ' check if saveFocus is true and set HomeScene node interface
-            if saveFocus then m.top.update({"focusedNode": focusedNode}, true)
-        end if
+    if node = invalid then return
+    focusedNode = invalid
+    if type(node) = "roSGNode"
+        focusedNode = node
+    else if type(node) = "String" and len(node) > 0
+        focusedNode = getScreen(node)
     end if
+    if focusedNode = invalid then return
+    focusedNode.setFocus(true)
+    ' createFields=true keeps non-BaseScreen callers (e.g. HomeScene) working
+    if saveFocus then m.top.update({"focusedNode": focusedNode}, true)
 end sub

--- a/components/utils/Themes.brs
+++ b/components/utils/Themes.brs
@@ -1,42 +1,18 @@
 sub setTheme(args as boolean, theme = { "type": "dark", "color": "red" } as object)
-    ' check if args is true
-    if (args)
-        ' check if theme was previously set by user
-        prevTheme = getThemeFromRegistry()
-        ' set theme to prevTheme if valid
-        if prevTheme <> invalid then theme = prevTheme
-        ' create initial palette Node
+    if not args then return
+    prevTheme = getThemeFromRegistry()
+    if prevTheme <> invalid then theme = prevTheme
+    themeColors = getTheme(theme)
+    if themeColors = invalid then return
+    homeScene = m.top.getScene()
+    if themeColors.palette <> invalid and themeColors.palette.count() > 0
         paletteNode = CreateObject("roSGNode", "RSGPalette")
-        ' get the theme colors and background
-        themeColors = getTheme(theme)
-        ' check that themeColors is not invalid
-        if (themeColors <> invalid)
-            ' get the top parent HomeScene node
-            homeScene = m.top.getScene()
-            ' set theme specific colors for the app if not invalid and object is not empty
-            if (themeColors.palette <> invalid and themeColors.palette.count() > 0)
-                ' assign the color theme to the palette node
-                paletteNode.colors = themeColors.palette
-                ' set palette to HomeScene node
-                homeScene.palette = paletteNode
-            end if
-            ' set theme specific background image URI for the app if valid and string is not empty
-            if (themeColors.backgroundUri <> invalid)
-                ' set background URI to HomeScene node
-                homeScene.backgroundUri = themeColors.backgroundUri
-            end if
-            ' set theme specific background color for the app if valid and string is not empty
-            if (themeColors.backgroundColor <> invalid)
-                ' set background color to HomeScene node
-                homeScene.backgroundColor = themeColors.backgroundColor
-            end if
-            ' set theme specific selector for rows/grids/lists if valid and string is not empty
-            if (themeColors.selectorUri <> invalid and len(themeColors.selectorUri) > 0)
-                ' set selector URI to HomeScene node
-                homeScene.selectorUri = themeColors.selectorUri
-            end if
-        end if
+        paletteNode.colors = themeColors.palette
+        homeScene.palette = paletteNode
     end if
+    if themeColors.backgroundUri <> invalid then homeScene.backgroundUri = themeColors.backgroundUri
+    if themeColors.backgroundColor <> invalid then homeScene.backgroundColor = themeColors.backgroundColor
+    if themeColors.selectorUri <> invalid and len(themeColors.selectorUri) > 0 then homeScene.selectorUri = themeColors.selectorUri
 end sub
 function getThemeFromRegistry() as object
     ' set theme to initial state
@@ -51,30 +27,14 @@ function getThemeFromRegistry() as object
     return theme
 end function
 function getTheme(theme as object) as dynamic
-    ' get json file from local storage
     themefile = ReadAsciiFile("pkg:/components/data/themes.json")
-    ' check that file exists
-    if (themefile <> invalid)
-        ' convert file to readable json
-        json = ParseJson(themefile)
-        ' check that json is valid
-        if (json <> invalid)
-            ' get dark or light theme (array)
-            themeType = json[theme.type]
-            ' check that theme array is valid and contains at least one entry
-            if (themeType <> invalid and themeType.count() > 0)
-                ' loop over color AA in theme array
-                for each color in themeType
-                    ' check that theme color exists (object)
-                    if (color[theme.color] <> invalid)
-                        ' return color object
-                        return color[theme.color]
-                        ' exit for loop
-                        exit for
-                    end if
-                end for
-            end if
-        end if
-    end if
+    if themefile = invalid then return invalid
+    json = ParseJson(themefile)
+    if json = invalid then return invalid
+    themeType = json[theme.type]
+    if themeType = invalid or themeType.count() = 0 then return invalid
+    for each color in themeType
+        if color[theme.color] <> invalid then return color[theme.color]
+    end for
     return invalid
 end function


### PR DESCRIPTION
## Summary

Mechanical refactor: replaces deeply-nested `if (x <> invalid)` pyramids with linear guard clauses + early returns across the utility and orchestration code. Comment noise that just described the next line is stripped along the way.

**Net: -243 lines, +116 lines. Zero behavior change.**

## Functions touched

| File | Function | Nesting before → after |
|---|---|---|
| [`components/HomeScene.brs`](../blob/refactor/guard-clauses/components/HomeScene.brs) | `addNode` | 5 levels → 1 |
| [`components/utils/Messages.brs`](../blob/refactor/guard-clauses/components/utils/Messages.brs) | `createDialog` | 4 levels → 1 |
| [`components/utils/Messages.brs`](../blob/refactor/guard-clauses/components/utils/Messages.brs) | `getMessage` | 3 levels → 1 |
| [`components/utils/Themes.brs`](../blob/refactor/guard-clauses/components/utils/Themes.brs) | `setTheme` | 3 levels → 1 |
| [`components/utils/Themes.brs`](../blob/refactor/guard-clauses/components/utils/Themes.brs) | `getTheme` | 4 levels → 1 |
| [`components/screens/dialogs/DialogModal.brs`](../blob/refactor/guard-clauses/components/screens/dialogs/DialogModal.brs) | `populateDialogBox` | 2 levels → 1 |
| [`components/utils/Screens.brs`](../blob/refactor/guard-clauses/components/utils/Screens.brs) | `getScreen` | 3 levels → 1 |
| [`components/utils/Screens.brs`](../blob/refactor/guard-clauses/components/utils/Screens.brs) | `screenExists` | 2 levels → 1 |
| [`components/utils/Screens.brs`](../blob/refactor/guard-clauses/components/utils/Screens.brs) | `removeScreen` | 3 levels → 1 |
| [`components/utils/Screens.brs`](../blob/refactor/guard-clauses/components/utils/Screens.brs) | `setFocus` | 3 levels → 1 |
| [`components/utils/History.brs`](../blob/refactor/guard-clauses/components/utils/History.brs) | `addHistory` | 4 levels → 1 |
| [`components/utils/History.brs`](../blob/refactor/guard-clauses/components/utils/History.brs) | `removeHistory` | 4 levels → 2 |

## Things worth a closer look during review

1. **`Messages.createDialog` no longer uses `messageValid`** — the sentinel boolean is gone; each failure path is its own early return with its own log line. Logic is identical.
2. **`Themes.setTheme` allocates `paletteNode` lazily** — previously created unconditionally before the `themeColors` check. Now created only when there's actually a palette to assign. Tiny perf win, no behavior change.
3. **`Themes.getTheme` drops a dead `exit for`** that was missed in the bug-fix PR (it followed a `return`, same pattern as Messages.brs and Requirements.brs from #10).
4. **`History.addHistory` and `removeHistory` now return `false` typed** when called with `invalid` instead of falling through to implicit `invalid`. Existing callers (`HomeScene.addNode`, `HomeScene.removeNode`) only check the boolean result, so this is safer.
5. **`Screens.setFocus` keeps the `createFields=true` flag** on `m.top.update()` — there's now a one-line comment explaining why (HomeScene callers don't have the field declared like BaseScreen subclasses do).

## What's NOT touched

- `Requirements.checkRequirements` — already pretty flat after the bug-fix PR; further restructuring would just shuffle the inherent loop logic.
- `BaseDialog.onTitleChange/onMessageChange/onBulletTextChange/onButtonChange` — already 2-level and follow a consistent pattern across all four. Flattening one without flattening all would create inconsistency, and they don't read poorly.
- `Screens.getAllScreens / showAllScreens`, `History.getHistory`, `General.brs`, `Main.brs` — already shallow.

## Testing

Visual diff review only. Each function was traced against its callers to verify equivalent semantics. No runtime testing — same caveat as the BaseScreen PR, sideload before / shortly after merging if possible.