### PR TITLE
Extract magic strings into Const() and cache messages.json

### DIFF
--- a/components/HomeScene.xml
+++ b/components/HomeScene.xml
@@ -7,6 +7,7 @@
 	<script type="text/brightscript" uri="pkg:/components/utils/History.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/Themes.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/General.brs" />
+	<script type="text/brightscript" uri="pkg:/components/utils/Constants.brs" />
 	<interface>
 		<field id="exitApp" type="boolean" value="false"/>
 		<field id="appLoaded" type="boolean" value="false"/>

--- a/components/screens/base/BaseScreen.xml
+++ b/components/screens/base/BaseScreen.xml
@@ -7,6 +7,7 @@
 	<script type="text/brightscript" uri="pkg:/components/utils/History.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/Themes.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/General.brs" />
+	<script type="text/brightscript" uri="pkg:/components/utils/Constants.brs" />
 	<interface>
 		<field id="focusedNode" type="node" />
 	</interface>

--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -80,20 +80,10 @@ sub onButtonChange(obj)
     end if
 end sub
 function onKeyEvent(key as string, press as boolean) as boolean
-    if (press)
-        if (key = "back")
-            ' get the dialog modal screen
-            dialogModal = getScreen("dialogModal")
-            ' check that the dialog modal is valid and contains the dialog info object and they count is greater than zero
-            if (dialogModal <> invalid and dialogModal.dialogInfo <> invalid and dialogModal.dialogInfo.count() > 0)
-                ' check if the dialog info object contains a key for allowBack and that it is set to true
-                if (dialogModal.dialogInfo.allowBack <> invalid and dialogModal.dialogInfo.allowBack)
-                    ' remove dialog modal screen
-                    removeScreen(dialogModal)
-                end if
-            end if
-            return true
-        end if
-    end if
-    return false
+    if not press then return false
+    if key <> Const().key.back then return false
+    dialogModal = getScreen("dialogModal")
+    if dialogModal = invalid or dialogModal.dialogInfo = invalid or dialogModal.dialogInfo.count() = 0 then return true
+    if dialogModal.dialogInfo.allowBack <> invalid and dialogModal.dialogInfo.allowBack then removeScreen(dialogModal)
+    return true
 end function

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -28,21 +28,16 @@ sub populateDialogBox(obj)
     createDialogNode(title, message, help, buttons)
 end sub
 sub onButtonSelected(obj)
-    ' get button index
     buttonIndex = obj.getData()
-    ' get button title
     buttonSelected = m.dialogNode.buttons[buttonIndex]
-    ' check if button pressed is "OKAY" or "YES"
-    if (buttonSelected = "OKAY" or buttonSelected = "YES")
-        ' check that closeApp is not invalid and set to true
-        if (m.dialogInfo.exitApp <> invalid and m.dialogInfo.exitApp)
-            ' immediately close the app
+    button = Const().button
+    if buttonSelected = button.okay or buttonSelected = button.yes
+        if m.dialogInfo.exitApp <> invalid and m.dialogInfo.exitApp
             m.top.getScene().exitApp = true
         else
             removeBaseDialog()
         end if
-        ' check if button pressed is "CANCEL" or "NO"
-    else if (buttonSelected = "CANCEL" or buttonSelected = "NO")
+    else if buttonSelected = button.cancel or buttonSelected = button.no
         removeBaseDialog()
     end if
 end sub

--- a/components/screens/landing/LandingScreen.brs
+++ b/components/screens/landing/LandingScreen.brs
@@ -71,20 +71,19 @@ sub onItemSelected(obj)
 end sub
 ' capture key events from remote control
 function onKeyEvent(key as string, press as boolean) as boolean
-    if (press)
-        if (key = "back")
-            ' send message to exit app
-            m.top.getScene().message = "exit"
-            return true
-        end if
-        if (key = "up")
-            ? "up key pressed"
-            return true
-        end if
-        if (key = "down")
-            ? "down key pressed"
-            return true
-        end if
+    if not press then return false
+    keys = Const().key
+    if key = keys.back
+        m.top.getScene().message = "exit"
+        return true
+    end if
+    if key = keys.up
+        ? "up key pressed"
+        return true
+    end if
+    if key = keys.down
+        ? "down key pressed"
+        return true
     end if
     return false
 end function

--- a/components/utils/Constants.brs
+++ b/components/utils/Constants.brs
@@ -1,0 +1,30 @@
+' Single source of truth for magic strings used across the channel.
+' Grouped by purpose; reference with e.g. Const().button.okay
+function Const() as object
+    return {
+        button: {
+            okay: "OKAY"
+            yes: "YES"
+            cancel: "CANCEL"
+            no: "NO"
+        }
+        key: {
+            back: "back"
+            up: "up"
+            down: "down"
+        }
+        path: {
+            messages: "pkg:/components/data/messages.json"
+            requirements: "pkg:/components/data/requirements.json"
+            themes: "pkg:/components/data/themes.json"
+        }
+        registry: {
+            theme: "theme"
+        }
+        beacon: {
+            dialogInitiate: "AppDialogInitiate"
+            dialogComplete: "AppDialogComplete"
+            launchComplete: "AppLaunchComplete"
+        }
+    }
+end function

--- a/components/utils/General.brs
+++ b/components/utils/General.brs
@@ -1,16 +1,15 @@
 sub dialogInit(node = m.top.getScene())
     ' Roku certification requires this to indicate a modal requires the users attention
-    if not node.appLoaded then node.signalBeacon("AppDialogInitiate")
+    if not node.appLoaded then node.signalBeacon(Const().beacon.dialogInitiate)
 end sub
 sub dialogComplete(node = m.top.getScene())
     ' Roku certification requires this to indicate the modal is closed
-    if not node.appLoaded then node.signalBeacon("AppDialogComplete")
+    if not node.appLoaded then node.signalBeacon(Const().beacon.dialogComplete)
 end sub
 sub appLoaded(node = m.top.getScene())
-    if (not node.appLoaded)
-        ' indicate that the app is now loaded
+    if not node.appLoaded
         node.appLoaded = true
         ' Roku certification requires this to indicate the app is finished loading
-        node.signalBeacon("AppLaunchComplete")
+        node.signalBeacon(Const().beacon.launchComplete)
     end if
 end sub

--- a/components/utils/Messages.brs
+++ b/components/utils/Messages.brs
@@ -23,11 +23,15 @@ sub showDialog(params as object, screen as object)
     screen.dialogInfo = params
 end sub
 function getMessage(messageString = "" as string)
-    messagefile = ReadAsciiFile("pkg:/components/data/messages.json")
-    if messagefile = invalid then return invalid
-    json = ParseJson(messagefile)
-    if json = invalid then return invalid
-    for each message in json.items()
+    ' parse messages.json once per component instance; the file ships in the package and never changes at runtime
+    if m.messageCache = invalid
+        messagefile = ReadAsciiFile(Const().path.messages)
+        if messagefile = invalid then return invalid
+        json = ParseJson(messagefile)
+        if json = invalid then return invalid
+        m.messageCache = json
+    end if
+    for each message in m.messageCache.items()
         if message.key = messageString and message.value <> invalid then return message.value
     end for
     return invalid

--- a/components/utils/Requirements.brs
+++ b/components/utils/Requirements.brs
@@ -6,14 +6,11 @@ function setRequirements(params as boolean) as boolean
     return true
 end function
 function createRequirements() as object
-    requirementsFile = ReadAsciiFile("pkg:/components/data/requirements.json")
-    if (requirementsFile <> invalid)
-        json = ParseJson(requirementsFile)
-        if (json <> invalid)
-            return json
-        end if
-    end if
-    return invalid
+    requirementsFile = ReadAsciiFile(Const().path.requirements)
+    if requirementsFile = invalid then return invalid
+    json = ParseJson(requirementsFile)
+    if json = invalid then return invalid
+    return json
 end function
 function checkRequirements(requirements as object) as boolean
     ' default to ready so empty or all-optional requirement sets pass the type contract

--- a/components/utils/Themes.brs
+++ b/components/utils/Themes.brs
@@ -15,19 +15,13 @@ sub setTheme(args as boolean, theme = { "type": "dark", "color": "red" } as obje
     if themeColors.selectorUri <> invalid and len(themeColors.selectorUri) > 0 then homeScene.selectorUri = themeColors.selectorUri
 end sub
 function getThemeFromRegistry() as object
-    ' set theme to initial state
     theme = invalid
-    ' create registry section
-    reg = createObject("roRegistrySection", "theme")
-    ' check that keys exist in the registry
-    if (reg.exists("type") and reg.exists("color"))
-        ' set theme to object from registry
-        theme = reg.readMulti(["type", "color"])
-    end if
+    reg = createObject("roRegistrySection", Const().registry.theme)
+    if reg.exists("type") and reg.exists("color") then theme = reg.readMulti(["type", "color"])
     return theme
 end function
 function getTheme(theme as object) as dynamic
-    themefile = ReadAsciiFile("pkg:/components/data/themes.json")
+    themefile = ReadAsciiFile(Const().path.themes)
     if themefile = invalid then return invalid
     json = ParseJson(themefile)
     if json = invalid then return invalid


### PR DESCRIPTION
## Summary

Two related changes in one PR:

1. **A5 — Constants extraction.** Adds [`components/utils/Constants.brs`](../blob/refactor/constants-and-cached-messages/components/utils/Constants.brs) with a single `Const()` function that returns an associative array of grouped string constants. Wired into `HomeScene.xml` and `BaseScreen.xml`. All call sites in the codebase that compared against literal strings now reference `Const().<group>.<name>`.

2. **A6 — Cached `messages.json`.** `getMessage` previously re-read and re-parsed `messages.json` from disk on every dialog. The file is part of the package; it never changes at runtime. Now parsed once, stashed on `m.messageCache`, looked up from memory on subsequent calls.

## Pattern chosen for constants

```brs
function Const() as object
    return {
        button: { okay: "OKAY", yes: "YES", cancel: "CANCEL", no: "NO" }
        key:    { back: "back", up: "up", down: "down" }
        path:   { messages: "pkg:/...", requirements: "pkg:/...", themes: "pkg:/..." }
        registry: { theme: "theme" }
        beacon: { dialogInitiate: "...", dialogComplete: "...", launchComplete: "..." }
    }
end function
```

Native BrightScript, no extras. Each call allocates the AA literal — cheap, and idiomatic for the language since there are no real `const` declarations. If you'd prefer per-constant functions (`function BTN_OKAY() return "OKAY"`) or caching the AA on `m`, easy to flip later.

## Call sites migrated

| File | What changed |
|---|---|
| [`DialogModal.brs`](../blob/refactor/constants-and-cached-messages/components/screens/dialogs/DialogModal.brs) | `onButtonSelected`: `"OKAY"/"YES"/"CANCEL"/"NO"` → `Const().button.*` |
| [`BaseDialog.brs`](../blob/refactor/constants-and-cached-messages/components/screens/dialogs/BaseDialog.brs) | `onKeyEvent`: `"back"` → `Const().key.back` |
| [`LandingScreen.brs`](../blob/refactor/constants-and-cached-messages/components/screens/landing/LandingScreen.brs) | `onKeyEvent`: `"back"/"up"/"down"` → `Const().key.*` |
| [`General.brs`](../blob/refactor/constants-and-cached-messages/components/utils/General.brs) | All three beacon names → `Const().beacon.*` |
| [`Themes.brs`](../blob/refactor/constants-and-cached-messages/components/utils/Themes.brs) | `"theme"` registry name → `Const().registry.theme`; themes.json path → `Const().path.themes` |
| [`Messages.brs`](../blob/refactor/constants-and-cached-messages/components/utils/Messages.brs) | messages.json path → `Const().path.messages` plus the new cache |
| [`Requirements.brs`](../blob/refactor/constants-and-cached-messages/components/utils/Requirements.brs) | requirements.json path → `Const().path.requirements` |

## Caching detail

```brs
function getMessage(messageString = "" as string)
    if m.messageCache = invalid
        messagefile = ReadAsciiFile(Const().path.messages)
        if messagefile = invalid then return invalid
        json = ParseJson(messagefile)
        if json = invalid then return invalid
        m.messageCache = json
    end if
    for each message in m.messageCache.items()
        if message.key = messageString and message.value <> invalid then return message.value
    end for
    return invalid
end function
```

- `m` here is HomeScene's `m` (`getMessage` is only called from `HomeScene.onMessage`), so the cache lives for the lifetime of the channel.
- File-read or parse failures don't poison the cache — `m.messageCache` stays `invalid` and the next call retries.

## What's NOT constantized (intentionally)

- **SceneGraph node type names** like `"RSGPalette"`, `"StdDlgButton"`, `"ContentNode"` — these are Roku API constants, not user-defined strings.
- **Roku type strings** `"roBoolean"` / `"roSGNode"` / `"String"` — built-in, stable.
- **XML interface field names** like `"exitApp"`, `"focusedNode"`, `"dialogInfo"` — already declared in XML interfaces; that's the source of truth.
- **Screen names / IDs** like `"LandingScreen"` / `"dialogModal"` — only one or two refs each; constantizing would add noise without much DRY win.

## Small side cleanups

While touching them, also flattened a couple of guards (`createRequirements`, `BaseDialog.onKeyEvent`) and stripped adjacent what-comments. The diff includes those — they're not behavior changes.

## Testing

Visual review only. No device test. Caveats from #11 and #13 still apply — sideload before / shortly after merging if possible. Particularly worth verifying: the dialog buttons (OKAY/YES/CANCEL/NO comparisons drive the exit-app and dismiss flows) and the messages.json cache on the second dialog open.