### PR TITLE
Fix typos and strip what-comments from BaseDialog and LandingScreen

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -1,20 +1,13 @@
 sub init()
-    ' change to true for testing themes set in /components/data/themes.json
-    ' the setTheme() has a 2nd argument for defining the theme ex. setTheme(true, { "type": "light", "color": "red" })
-    ' ensure that both the "type" and "color" inside the object match the key/values in themes.json
+    ' setTheme(true) applies default; pass {"type":"light","color":"red"} matching /components/data/themes.json to override
     setTheme(true)
-    ' set to true for forcing requirements in /components/data/requirements.json
-    ' set to false to immediately return true and bypass requirements
-    ' optional: test the error message for requirements by changing the minVersion in the requirements.json file from to 20.0
+    ' setRequirements(true) enforces /components/data/requirements.json; bump minVersion there to test the OS-update error path
     requirements = setRequirements(false)
-    ' start the app if all requirements are met
     if requirements then startApp()
 end sub
 sub startApp()
-    ' create the initial screen stack array in History.brs
     initScreenStack()
-    ' create the landing screen node (name) and assign an id
-    ' see REAMDME for additional arguments
+    ' see README for addScreen() arguments
     addScreen("LandingScreen", "landingScreen")
 end sub
 function addNode(params as object) as object
@@ -38,22 +31,19 @@ function addNode(params as object) as object
     return node
 end function
 sub removeNode(params as object)
-    if (not removeHistory(params.node, params.showPrevScreen, params.removeFromStack))
-        ' show a console message stating that the node could not be added to HomeScene
+    if not removeHistory(params.node, params.showPrevScreen, params.removeFromStack)
         ? " "
         ? "there was an error removing the node from HomeScene"
     end if
 end sub
 sub onMessage(obj)
-    ' get the message string
     message = obj.getData()
-    if (message <> invalid and len(message) > 0)
-        ' guard against an unknown key so the dialog code isn't called with invalid
-        params = getMessage(message)
-        if (params <> invalid)
-            createDialog(params)
-        else
-            ? "no message found for key: " + message + " - HomeScene.brs"
-        end if
+    if message = invalid or len(message) = 0 then return
+    ' guard against an unknown key so the dialog code isn't called with invalid
+    params = getMessage(message)
+    if params = invalid
+        ? "no message found for key: " + message + " - HomeScene.brs"
+        return
     end if
+    createDialog(params)
 end sub

--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -1,5 +1,4 @@
 sub init()
-    ' check if the node ID is invalid or string length of node ID is zero
     if m.top.id = invalid or len(m.top.id) = 0 then m.top.id = "baseDialog"
     m.titlearea = m.top.findNode("titleArea")
     m.contentarea = m.top.findNode("contentArea")
@@ -9,75 +8,38 @@ sub init()
 end sub
 sub onTitleChange(obj)
     title = obj.getData()
-    ' check that the existing titla area text is not invalid and is not an empty string
-    if (m.titlearea <> invalid and len(m.titlearea.primaryTitle) > 0)
-        ' reset the title area text
-        m.titlearea.primaryTitle = ""
-    end if
-    ' check that the new title is not invalid and is not an empty string
-    if (title <> invalid and len(title) > 0)
-        ' set the title
-        m.titlearea.primaryTitle = title
-    end if
+    if m.titlearea <> invalid and len(m.titlearea.primaryTitle) > 0 then m.titlearea.primaryTitle = ""
+    if title <> invalid and len(title) > 0 then m.titlearea.primaryTitle = title
 end sub
 sub onMessageChange(obj)
     message = obj.getData()
-    ' check that the existing message text is not invalid and is not an empty string
-    if (m.messagetext <> invalid and len(m.messagetext.text) > 0)
-        ' reset the message text
-        m.messagetext.text = ""
-    end if
-    ' check that the new message is not invalid and is not an empty string
-    if (message <> invalid and len(message) > 0)
-        ' set the  message
-        m.messagetext.text = message
-        'set the message type
-        m.messagetext.namedTextStyle = "bold"
-        ' set the message text size
-        m.messagetext.getChild(0).font.size = 32
-    end if
+    if m.messagetext <> invalid and len(m.messagetext.text) > 0 then m.messagetext.text = ""
+    if message = invalid or len(message) = 0 then return
+    m.messagetext.text = message
+    m.messagetext.namedTextStyle = "bold"
+    m.messagetext.getChild(0).font.size = 32
 end sub
 sub onBulletTextChange(obj)
     bullets = obj.getData()
-    ' check that the existing bullet text array is not invalid and is not an empty array
-    if (m.bulletarea <> invalid and m.bulletarea.bulletText.count() > 0)
-        ' reset the bullet text array
-        m.bulletarea.bulletText = []
-    end if
-    ' check that the new bullet array is not invalid and is not an empty array
-    if (bullets <> invalid and bullets.count() > 0)
-        ' set the bullet text
-        m.bulletarea.bulletText = bullets
-        ' loop over each node inside bullet area
-        for each node in m.bulletarea.getChild(0).getChildren(-1, 0)
-            ' set the text color
-            node.update({ "color": m.top.getScene().palette.colors.dialogBulletTextColor }, true)
-            ' set the text size
-            node.font.size = 29
-        end for
-    end if
+    if m.bulletarea <> invalid and m.bulletarea.bulletText.count() > 0 then m.bulletarea.bulletText = []
+    if bullets = invalid or bullets.count() = 0 then return
+    m.bulletarea.bulletText = bullets
+    for each node in m.bulletarea.getChild(0).getChildren(-1, 0)
+        node.update({ "color": m.top.getScene().palette.colors.dialogBulletTextColor }, true)
+        node.font.size = 29
+    end for
 end sub
 sub onButtonChange(obj)
     buttons = obj.getData()
-    ' check that the existing button node is not invalid and is not an empty node array
-    if (m.buttonarea <> invalid and m.buttonarea.getChildCount() > 0)
-        ' get all child nodes from inside the button area node
-        childNodes = m.buttonarea.getChildren(-1, 0)
-        ' remove all child nodes from inside the button area node
-        m.buttonarea.removeChildren(childNodes)
+    if m.buttonarea <> invalid and m.buttonarea.getChildCount() > 0
+        m.buttonarea.removeChildren(m.buttonarea.getChildren(-1, 0))
     end if
-    ' check that the new button array is not invalid and is not an empty array
-    if (buttons <> invalid and buttons.count() > 0)
-        ' loop over each new button
-        for each button in buttons
-            ' create a button node
-            buttonNode = createObject("roSGNode", "StdDlgButton")
-            ' set the button text
-            buttonNode.text = button
-            ' add the new button node to the button area node
-            m.buttonarea.appendChild(buttonNode)
-        end for
-    end if
+    if buttons = invalid or buttons.count() = 0 then return
+    for each button in buttons
+        buttonNode = createObject("roSGNode", "StdDlgButton")
+        buttonNode.text = button
+        m.buttonarea.appendChild(buttonNode)
+    end for
 end sub
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false

--- a/components/screens/landing/LandingScreen.brs
+++ b/components/screens/landing/LandingScreen.brs
@@ -12,62 +12,41 @@ sub onScreenVisible()
     appLoaded()
 end sub
 sub setLandingTitle()
-    ' set the text string for the title label - tr() is optional for translating the string to another language
+    ' tr() is optional — pass plain strings if you don't need translations
     m.landingTitle.text = tr("Welcome To The Landing Screen")
-    ' set the font size for the title label
     m.landingTitle.font.size = 62
-    ' set the label color using the palette from the home scene node
     m.landingTitle.color = m.top.getScene().palette.colors.primaryTextColor
 end sub
 sub populateLabelList()
-    ' create array of strings to be displayed in the label list
-    ' tr() is optional for translating to another language
+    ' tr() is optional — pass plain strings if you don't need translations
     listItems = [
         tr("Sign In"),
         tr("Register"),
         tr("Exit")
     ]
-    ' create parent content node
     parentNode = createObject("roSGNode", "ContentNode")
-    ' loop over the list items
     for each item in listItems
-        ' create child content node to hold list data
         childNode = createObject("roSGNode", "ContentNode")
-        ' use the list item string as the title for the content node
         childNode.title = item
-        ' add the child node to the parent node
         parentNode.appendChild(childNode)
     end for
-    ' assign the parent node to the label list content
     m.labelList.content = parentNode
 end sub
 sub setLabelList()
-    '### set location of label list ###
-    ' locate the horiz midpoint using screen UI width and the total width of the label list
+    ' center the label list within the UI viewport
     labelListX = (m.global.ui.width - m.labelList.boundingRect().width) / 2
-    ' locate the vert midpoint using screen UI height and the total height of the label list
     labelListY = (m.global.ui.height - m.labelList.boundingRect().height) / 2
-    ' set the label list X and Y coordinates
     m.labelList.translation = [labelListX, labelListY]
 
-    '### set color and overall theme of label list ###
-    ' check if the top level selector URI is valid and set to label list
+    ' theme the label list using the HomeScene palette
     if m.top.getScene().selectorUri <> invalid then m.labelList.focusBitmapUri = m.top.getScene().selectorUri
-    ' set the unfocused label color using the palette from the home scene node
     m.labelList.color = m.top.getScene().palette.colors.primaryTextColor
-    ' set the focused label color using the palette from the home scene node
     m.labelList.focusedColor = m.top.getScene().palette.colors.primaryTextColor
 end sub
 sub onItemSelected(obj)
-    ' get the index from the selection
     itemIndex = obj.getData()
-    ' get the item from the content nodes using the item index
     itemSelected = m.labelList.content.getChild(itemIndex)
-    ' observe when the exit key is selected
-    if (itemSelected.title = tr("Exit"))
-        ' send message to exit app
-        m.top.getScene().message = "exit"
-    end if
+    if itemSelected.title = tr("Exit") then m.top.getScene().message = "exit"
 end sub
 ' capture key events from remote control
 function onKeyEvent(key as string, press as boolean) as boolean


### PR DESCRIPTION
## Summary

The closing cleanup PR for the audit. Two typos + a comment-noise sweep of the largest remaining offenders.

**Net: -69 lines across 3 files. Zero behavior change.**

## Typos

- [`HomeScene.brs:17`](../blob/chore/typos-and-comment-cleanup/components/HomeScene.brs#L8) — `REAMDME` → `README`
- [`BaseDialog.brs:12`](../blob/chore/typos-and-comment-cleanup/components/screens/dialogs/BaseDialog.brs#L9) — dropped the `existing titla area text` comment (it was both a typo and a what-comment for the next line, so removing it solves both problems)

(The other typos called out in the original audit — `valud`, `usind`, `they count` — got swept up incidentally in PRs #10, #11, and #13 when the surrounding code was rewritten.)

## Comment cleanup

Following the codebase's standing rule — *comments should explain why, not what* — these files had clusters of `' check that X is not invalid` lines describing the next condition verbatim. Stripped where redundant; kept where they add real information.

### `HomeScene.brs`
- `init`: the 3-line meta-comments on `setTheme`/`setRequirements` (which document the override-object shape and how to test the error path) condensed to one informative line each.
- `removeNode`: dropped the comment that said the function couldn't *add* a node — it's the remove path.
- `onMessage`: flattened with guard clauses (consistent with the rest of the codebase post-PR #13). Kept the line about guarding against unknown keys.

### `BaseDialog.brs`
The four `onChange` handlers (`onTitleChange`, `onMessageChange`, `onBulletTextChange`, `onButtonChange`) were each ~10 lines of which ~half were noise. Compressed to inline `then` statements or guard-clause `return`s. The 4 handlers are still a consistent pattern across all of them.

Also dropped a malformed `'set the message type` comment (missing space, misleading word — `namedTextStyle = "bold"` isn't a "type") and the `' set the message text size` comment above an obvious `.font.size = 32` line.

### `LandingScreen.brs`
`setLandingTitle`, `populateLabelList`, `setLabelList`, `onItemSelected` — same treatment. Kept the two `tr()` notes (they explain *why* translation calls are there even though the boilerplate ships in English) and rewrote the two section dividers in `setLabelList` to express intent (`center the label list within the UI viewport` / `theme the label list using the HomeScene palette`) instead of describing the next line.

## Out of scope (intentionally not touched)

- `Screens.getAllScreens` / `showAllScreens` / `History.getHistory` — debug-only helper functions, verbose comments arguably useful for boilerplate readers learning the pattern.
- `Themes.setTheme` / `Themes.getTheme` — already cleaned in PR #13/#14.
- `Messages.brs`, `Requirements.brs`, `General.brs`, `Constants.brs`, `BaseScreen.brs`, `DialogModal.brs` — clean from earlier PRs.

## What's left after this PR

I don't see anything else in the codebase that's clearly worth touching as a maintenance pass. Possible future directions, but not maintenance work:

- **A4 (util-script-loading reshuffle)** — debatable scope; can stay as-is.
- **Feature additions** — new example screens, a real theme switcher, a `--demo` mode. These are productization, not cleanup.

## Testing

Visual review only. No device test. Comment removal is zero-risk by definition; the guard-clause restructuring in `onMessage` and the four `onChange` handlers preserves the exact same conditional logic, just expressed more compactly.