### PR TITLE
Add Logger utility and migrate inline print calls

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -25,15 +25,13 @@ function addNode(params as object) as object
     if addHistory(node, params.showScreen, params.hidePrevScreen, params.addToStack)
         node.setFocus(true)
     else
-        ? " "
-        ? "there was an error adding " + node.id + " to HomeScene"
+        logError("error adding " + node.id + " to HomeScene", "HomeScene.brs")
     end if
     return node
 end function
 sub removeNode(params as object)
     if not removeHistory(params.node, params.showPrevScreen, params.removeFromStack)
-        ? " "
-        ? "there was an error removing the node from HomeScene"
+        logError("error removing node from HomeScene", "HomeScene.brs")
     end if
 end sub
 sub onMessage(obj)
@@ -42,7 +40,7 @@ sub onMessage(obj)
     ' guard against an unknown key so the dialog code isn't called with invalid
     params = getMessage(message)
     if params = invalid
-        ? "no message found for key: " + message + " - HomeScene.brs"
+        logError("no message found for key: " + message, "HomeScene.brs")
         return
     end if
     createDialog(params)

--- a/components/HomeScene.xml
+++ b/components/HomeScene.xml
@@ -8,6 +8,7 @@
 	<script type="text/brightscript" uri="pkg:/components/utils/Themes.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/General.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/Constants.brs" />
+	<script type="text/brightscript" uri="pkg:/components/utils/Logger.brs" />
 	<interface>
 		<field id="exitApp" type="boolean" value="false"/>
 		<field id="appLoaded" type="boolean" value="false"/>

--- a/components/screens/base/BaseScreen.xml
+++ b/components/screens/base/BaseScreen.xml
@@ -8,6 +8,7 @@
 	<script type="text/brightscript" uri="pkg:/components/utils/Themes.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/General.brs" />
 	<script type="text/brightscript" uri="pkg:/components/utils/Constants.brs" />
+	<script type="text/brightscript" uri="pkg:/components/utils/Logger.brs" />
 	<interface>
 		<field id="focusedNode" type="node" />
 	</interface>

--- a/components/screens/landing/LandingScreen.brs
+++ b/components/screens/landing/LandingScreen.brs
@@ -57,11 +57,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
         return true
     end if
     if key = keys.up
-        ? "up key pressed"
+        logDebug("up key pressed", "LandingScreen.brs")
         return true
     end if
     if key = keys.down
-        ? "down key pressed"
+        logDebug("down key pressed", "LandingScreen.brs")
         return true
     end if
     return false

--- a/components/utils/History.brs
+++ b/components/utils/History.brs
@@ -30,13 +30,12 @@ function removeHistory(node as object, showPrevScreen as boolean, removeFromStac
     return m.top.removeChild(node)
 end function
 sub getHistory()
-    ' check that the screen stack array is valid and contains items
-    if (m.screenStack <> invalid and m.screenStack.count() > 0)
-        ' show a console message containing the array items
-        ? m.screenStack
-    else
-        ' show a console message stating the history is empty
-        ? " "
-        ? "there are no history items"
+    if m.screenStack = invalid or m.screenStack.count() = 0
+        logDebug("screen stack is empty", "History.brs")
+        return
     end if
+    logDebug("screen stack contents:", "History.brs")
+    for each node in m.screenStack
+        logDebug(" -> " + node.subType() + " (id=" + node.id + ")", "History.brs")
+    end for
 end sub

--- a/components/utils/Logger.brs
+++ b/components/utils/Logger.brs
@@ -1,0 +1,25 @@
+' Centralized logging. Errors and warnings are always printed; info and debug
+' are suppressed unless m.global.devLogging is true.
+' Source is optional but useful for grep.
+sub logError(msg as string, source = "" as string)
+    ? " "
+    ? "[ERROR] " + msg + sourceTag(source)
+end sub
+sub logWarn(msg as string, source = "" as string)
+    ? "[WARN] " + msg + sourceTag(source)
+end sub
+sub logInfo(msg as string, source = "" as string)
+    if not devLoggingEnabled() then return
+    ? "[INFO] " + msg + sourceTag(source)
+end sub
+sub logDebug(msg as string, source = "" as string)
+    if not devLoggingEnabled() then return
+    ? "[DEBUG] " + msg + sourceTag(source)
+end sub
+function sourceTag(source as string) as string
+    if len(source) = 0 then return ""
+    return "  (" + source + ")"
+end function
+function devLoggingEnabled() as boolean
+    return m.global <> invalid and m.global.devLogging = true
+end function

--- a/components/utils/Messages.brs
+++ b/components/utils/Messages.brs
@@ -1,15 +1,14 @@
 sub createDialog(params = {} as object)
     if params = invalid
-        ? "message is not an object - Messages.brs"
+        logError("message is not an object", "Messages.brs")
         return
     end if
     if params.count() = 0
-        ? "message is empty - Messages.brs"
+        logError("message is empty", "Messages.brs")
         return
     end if
     if params.title = invalid or len(params.title) = 0
-        ? "message title is required - Messages.brs"
-        ? "message is: "; params
+        logError("message title is required; contents: " + FormatJson(params), "Messages.brs")
         return
     end if
     if screenExists("dialogModal")

--- a/components/utils/Screens.brs
+++ b/components/utils/Screens.brs
@@ -1,13 +1,11 @@
 function getScreen(screenId as string, showScreen = false as boolean)
     if screenId = invalid or len(screenId) = 0
-        ? " "
-        ? "you must set a valid id (string) for screenId"
+        logError("invalid screenId passed to getScreen", "Screens.brs")
         return invalid
     end if
     node = m.top.getScene().findNode(screenId)
     if node = invalid
-        ? " "
-        ? screenId + " was not found"
+        logWarn(screenId + " was not found", "Screens.brs")
         return invalid
     end if
     if not node.visible and showScreen then node.visible = true
@@ -15,25 +13,18 @@ function getScreen(screenId as string, showScreen = false as boolean)
 end function
 function screenExists(screenId as string) as boolean
     if screenId = invalid or len(screenId) = 0
-        ? " "
-        ? "screen not found"
+        logError("invalid screenId passed to screenExists", "Screens.brs")
         return false
     end if
     return getScreen(screenId) <> invalid
 end function
 function addScreen(screenName as string, screenId = invalid as string, showScreen = true as boolean, hidePrevScreen = true as boolean, addToStack = true as boolean) as object
-    ' check if screenId is invalid or empty
     if screenId = invalid or screenId.len() = 0
-        ' assign the screenName to the screenId
         screenId = screenName
-        ? " "
-        ? "No screen ID assigned for " + screenName + " node. Using " + screenName + " as ID"
+        logInfo("no screen id assigned for " + screenName + " node; using " + screenName + " as id", "Screens.brs")
     end if
-    ' check if the screenId is already been given to an existing screen node
     if screenExists(screenId)
-        ? " "
-        ? "The id '" + screenId + "' is already assigned to another screen node. Please create a new id for this node."
-        ' refuse to add a duplicate; callers already null-check the return
+        logError("id '" + screenId + "' already assigned to another screen node", "Screens.brs")
         return invalid
     end if
     return m.top.getScene().callFunc("addNode", {"screenName": screenName, "showScreen": showScreen, "screenId": screenId, "hidePrevScreen": hidePrevScreen, "addToStack": addToStack})
@@ -61,21 +52,15 @@ function getAllScreens() as dynamic
     end if
 end function
 sub showAllScreens()
-    ' get the full array of child nodes from HomeScene
     screenArray = getAllScreens()
-    ' check that the screen array is valid and has an item count of greater than zero
-    if (screenArray <> invalid and screenArray.count() > 0)
-        ? "valid screens/nodes from HomeScene.xml:"
-        ' loop over each screen in the array and print to console
-        for each screen in screenArray
-            ? " -> " + screen
-        end for
-        ? " "
-    else
-        ' show a console message stating that there are no child nodes in HomeScene
-        ? "there are no valid screens/nodes in HomeScene.xml:"
-        ? " "
+    if screenArray = invalid or screenArray.count() = 0
+        logDebug("no valid screens/nodes in HomeScene", "Screens.brs")
+        return
     end if
+    logDebug("valid screens/nodes in HomeScene:", "Screens.brs")
+    for each screen in screenArray
+        logDebug(" -> " + screen.subType() + " (id=" + screen.id + ")", "Screens.brs")
+    end for
 end sub
 sub setFocus(node as dynamic, saveFocus = true as boolean)
     if node = invalid then return

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -4,6 +4,7 @@ sub main(args)
     showAppInfo = false ' show app info in the console
     showBandwidth = false ' show bandwidth utilization
     showHttpErrors = false ' show http and url errors
+    devLogging = true ' show logInfo/logDebug output (logError/logWarn always print)
     '########################################################################
 
     '########################### DEVICE/APP INFO ############################
@@ -23,7 +24,7 @@ sub main(args)
     ' create root scenegraph node
     screen = createObject("roSGScreen")
     ' set global values using info obtained from device and app
-    setGlobals(screen, deviceInfo, appInfo, args)
+    setGlobals(screen, deviceInfo, appInfo, args, devLogging)
     ' set the message port for screen events
     screen.setMessagePort(port)
     ' create the initial scenegraph object
@@ -165,10 +166,8 @@ sub getAppInfo(appInfo)
     ? "- - - - - - - - - - - - - - - - - - -"
     ? " "
 end sub
-sub setGlobals(screen, deviceInfo, appInfo, deepLinkArgs)
-    ' get the global reference object
+sub setGlobals(screen, deviceInfo, appInfo, deepLinkArgs, devLogging = true as boolean)
     m.global = screen.getGlobalNode()
-    ' assign variables to global object
     m.global.addFields({
         "deviceId": deviceInfo.id,
         "model": deviceInfo.model,
@@ -178,7 +177,8 @@ sub setGlobals(screen, deviceInfo, appInfo, deepLinkArgs)
         "graphics": deviceInfo.graphics,
         "ui": deviceInfo.display.ui,
         "hdcp": deviceInfo.hdmi.hdcp,
-        "deeplink": getDeepLinks(deepLinkArgs)
+        "deeplink": getDeepLinks(deepLinkArgs),
+        "devLogging": devLogging
     })
 end sub
 function getDeepLinks(args) as object


### PR DESCRIPTION
## Summary

Replaces ~20 inline `?` print statements with four direct logging functions: `logError`, `logWarn`, `logInfo`, `logDebug`. Adds a `devLogging` developer flag in `Main.brs` that suppresses info/debug for production builds; error and warn always print.

## API

```brs
logError("node not found",        "Screens.brs")
logWarn(screenId + " was not found", "Screens.brs")
logInfo("no screen id assigned for " + name, "Screens.brs")
logDebug("up key pressed",        "LandingScreen.brs")
```

Output format: `[LEVEL] message  (Source.brs)`. Source is optional. Errors are also prefixed with a blank line to preserve the visual separation that the previous `? " "` pattern provided.

## Files added / changed

- **NEW** [`components/utils/Logger.brs`](../blob/refactor/logger-utility/components/utils/Logger.brs)
- [`components/HomeScene.xml`](../blob/refactor/logger-utility/components/HomeScene.xml), [`components/screens/base/BaseScreen.xml`](../blob/refactor/logger-utility/components/screens/base/BaseScreen.xml) — added the `<script>` tag.
- [`source/Main.brs`](../blob/refactor/logger-utility/source/Main.brs) — new `devLogging = true` developer variable alongside the existing `showDeviceInfo` / `showAppInfo` / etc. flags; passed through `setGlobals`, which now writes `m.global.devLogging`.
- Migrations in `HomeScene.brs`, `Screens.brs`, `Messages.brs`, `History.brs`, `LandingScreen.brs` (call-by-call detail in the commit message).

## Level mapping

| Site | Old | New |
|---|---|---|
| `HomeScene.addNode` failure | `?` | `logError` |
| `HomeScene.removeNode` failure | `?` | `logError` |
| `HomeScene.onMessage` unknown key | `?` | `logError` |
| `Screens.getScreen` invalid id | `?` | `logError` |
| `Screens.getScreen` not found | `?` | `logWarn` |
| `Screens.screenExists` invalid id | `?` | `logError` |
| `Screens.addScreen` no id given | `?` | `logInfo` |
| `Screens.addScreen` duplicate id | `?` | `logError` |
| `Screens.showAllScreens` dev dump | `?` | `logDebug` |
| `Messages.createDialog` (3 paths) | `?` | `logError` |
| `History.getHistory` dev dump | `?` | `logDebug` |
| `LandingScreen.onKeyEvent` up/down | `?` | `logDebug` |

The `addScreen "no id given"` case dropped from error to info — it's informational (the function self-recovers by using `screenName` as the id) and was misleading to flag at the same severity as a duplicate.

## Suppression behavior

`logInfo` / `logDebug` check `m.global.devLogging` and return early if false. Safe against `m.global` being uninitialized (returns false). To silence them in a production build, change one line in `Main.brs`:

```brs
devLogging = false
```

## Out of scope (intentionally not migrated)

- `Main.brs getDeviceInfo` / `getAppInfo` — multi-line column-aligned table output, more readable as plain `?` than as a flood of `logDebug` lines. Already gated by their own `showDeviceInfo` / `showAppInfo` flags.
- `Main.brs` HTTP error / bandwidth handlers — same reasoning; they have their own structured multi-line shape and existing toggle flags.

These could be folded in later if you want a single unified gating flag, but the right call here felt like leaving them alone.

## Testing

Visual review only. Migrations are 1:1 — no log site was added, removed, or merged (except `Messages.brs` "title required" + "message is:" which were combined into one `logError` line with the params dumped as JSON).