### PR TITLE
Update README for audit additions and a few stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,18 @@ _A starting point for new Roku applications._
 - [X] Preset globals
 - [X] Theme customization
 - [X] Node management + history + focus
+- [X] BaseScreen with lifecycle hooks (`onScreenInit` / `onScreenVisible` / `onScreenHidden`)
+- [X] Centralized constants via `Const()`
+- [X] Leveled logging via `logError` / `logWarn` / `logInfo` / `logDebug`
 - [X] Translations
 - [X] Pop-up dialogs
 - [ ] Testing (Not yet implemented)
 
 
  ## Requirements
- * A Roku device with a minimum OS version of 9.4**
+ * A Roku device with a minimum OS version of 10.0**
 
-    ** _earlier OS versions may not compile due to deprecated libraries_
+    ** _enforced at startup by [/components/data/requirements.json](/components/data/requirements.json); earlier OS versions may also fail to compile due to deprecated libraries_
 
  * [Developer mode enabled](https://developer.roku.com/docs/developer-program/getting-started/developer-setup.md)
 
@@ -23,7 +26,7 @@ _A starting point for new Roku applications._
  ## Installation
  * This project uses the [VSCode](https://code.visualstudio.com/) IDE along with the [BrightScript Language Extension](https://marketplace.visualstudio.com/items?itemName=RokuCommunity.brightscript) for packaging and deploying builds.
  * Clone the repository to your preferred folder
- * Rename the ".env_sample" file to ".env". This file is located at the root of the project folder.
+ * Rename the ".env-sample" file to ".env". This file is located at the root of the project folder.
     * ROKU_HOST = your Roku device IP address
     * ROKU_USERNAME = "rokudev" (default)
     * ROKU_PASSWORD = the password you set when enabling developer mode
@@ -40,6 +43,25 @@ ZIP file is automatically generated in /out/roku-deploy.zip and sent to your Rok
     * Enabling (true) "showDeviceInfo" and/or "showAppInfo" at the top of [/source/Main.brs](/source/Main.brs) will print information about the device to the console.
 * If the app closes, the console/debug session will automatically close
 
+### Logging
+Use the leveled helpers in [/components/utils/Logger.brs](/components/utils/Logger.brs) instead of inline `?` statements:
+```
+logError("something failed", "Source.brs")
+logWarn("deeplink missing mediaType")
+logInfo("App loaded")
+logDebug("up key pressed", "LandingScreen.brs")
+```
+Output format: `[LEVEL] message  (Source.brs)`. The source argument is optional but useful for grep.
+
+| Level | When printed |
+|---|---|
+| `logError` | Always (prefixed with a blank line) |
+| `logWarn` | Always |
+| `logInfo` | Only when `m.global.devLogging` is true |
+| `logDebug` | Only when `m.global.devLogging` is true |
+
+`devLogging` is declared at the top of [/source/Main.brs](/source/Main.brs) alongside `showDeviceInfo` / `showAppInfo` / `showBandwidth` / `showHttpErrors`. Set it to `false` for a quieter production build.
+
 
 ## Configuration
 ### Globals
@@ -48,8 +70,10 @@ Roku uses "m.global" to reference an object as seen in [/source/Main.brs](/sourc
 ![Screenshot](/docs/images/globals.png)
 
 * Global object values can be accessed from anywhere in the app.
-    * m.global.ui could return a value of "HD" or "FHD". This would be useful in determing the background poster size to load from a remote image source (HD = 1280 x 720, FHD = 1920 x 1080)
-    * 4 of the global object keys (model, os, internet, hdcp) are used with [/components/data/requirements.json](/components/data/requirements.json) to determine app eligibility at startup. See Requirements for more info.
+    * `m.global.ui` could return a value of "HD" or "FHD". This is useful when picking remote image sizes (HD = 1280 x 720, FHD = 1920 x 1080).
+    * 4 of the keys (`model`, `os`, `internet`, `hdcp`) are used with [/components/data/requirements.json](/components/data/requirements.json) to determine app eligibility at startup. See Requirements for more info.
+    * `deeplink` is set from the launch args (`contentId` / `mediaType`) when present. See `getDeepLinks` in [/source/Main.brs](/source/Main.brs).
+    * `devLogging` controls whether `logInfo` / `logDebug` output is printed. See Logging.
 
 <br/><br/>
 ### Themes
@@ -77,7 +101,36 @@ The root SceneGraph node in Roku (/components/HomeScene.xml) contains a palette 
  ```
 
 <br/><br/>
+### Constants
+Magic strings (button labels, key codes, file paths, registry section, beacon names) live in [/components/utils/Constants.brs](/components/utils/Constants.brs) as an AA returned by `Const()`:
+```
+buttonSelected = Const().button.okay   ' "OKAY"
+key = Const().key.back                  ' "back"
+ReadAsciiFile(Const().path.messages)    ' "pkg:/components/data/messages.json"
+node.signalBeacon(Const().beacon.launchComplete)
+```
+Add new groups to `Const()` rather than introducing new literals in call sites. See [/components/utils/Constants.brs](/components/utils/Constants.brs) for the full table.
+
+<br/><br/>
 ### Node Management
+#### Screen Lifecycle Hooks
+Any screen that extends `BaseScreen` inherits a default `init()` that hides the screen, observes its `visible` field, and dispatches to three optional hooks. Override these in your screen's `.brs` file instead of redefining `init()` directly:
+```
+sub onScreenInit()
+    ' run once when the node is created — set up node references and field observers
+end sub
+sub onScreenVisible()
+    ' run every time the screen becomes visible — fetch data, set focus, etc.
+end sub
+sub onScreenHidden()
+    ' run every time the screen is hidden — pause animations, cancel requests, etc.
+end sub
+```
+> Each hook is a no-op by default. Implementing one in a subclass overrides the parent's no-op since SceneGraph loads child scripts after the parent's.
+> See [/components/screens/landing/LandingScreen.brs](/components/screens/landing/LandingScreen.brs) for a working example.
+
+`BaseScreen` also declares a `focusedNode` field on its interface, used by `setFocus(node, saveFocus)` to remember which child node was last focused — see Setting screen focus below.
+
 #### Adding a new node to the root scene node:
 > If "screenId" is not set, the "screenName" will be used as the node ID. If the ID is already being used, a console warning will appear.
 ```
@@ -133,17 +186,16 @@ Additional arguments can be used as follows:
 ```
 setFocus(
    node        ' the node or the node ID
-   saveFocus   ' adds the node to focusedNode field (true by default)
+   saveFocus   ' writes the focused node to m.top's focusedNode field (true by default)
 )
 ```
+> `focusedNode` is declared on the `BaseScreen` interface. When a BaseScreen-derived screen becomes visible again after being hidden, `removeHistory` reads this field and re-focuses the saved node.
 
 
 #### Note
-In order to use the node management library, each XML file requires a top level script assigned as follows:
-```
-<script type="text/brightscript" uri="pkg:/components/utils/Screens.brs" />
-```
-> also see [/components/screens/landing/LandingScreen.xml](/components/screens/landing/LandingScreen.xml)
+Screens extending `BaseScreen` automatically inherit every utility script (`Screens.brs`, `History.brs`, `Themes.brs`, `Messages.brs`, `Requirements.brs`, `General.brs`, `Constants.brs`, `Logger.brs`) via the parent component's `<script>` tags — you don't need to re-include them. The only place to register new utilities is in [/components/screens/base/BaseScreen.xml](/components/screens/base/BaseScreen.xml) (and [/components/HomeScene.xml](/components/HomeScene.xml) if HomeScene also needs the utility).
+
+> See [/components/screens/landing/LandingScreen.xml](/components/screens/landing/LandingScreen.xml) for a working example.
 
 <br/><br/>
 ### Translations
@@ -159,7 +211,7 @@ A pop-up message or notification can be generated as follows:
 setMessage("message")
 ```
 The string passed to setMessage is assigned using data from [/components/data/messages.json](/components/data/messages.json):
-> buttons are limited to the ones listed here. This can be further customized in `onButtonSelected()` at [/components/screens/dialogs/DialogModal.brs](/components/screens/dialogs/DialogModal.brs)
+> Buttons are limited to the four listed below. To change per-button behavior, edit `onButtonSelected()` in [/components/screens/dialogs/DialogModal.brs](/components/screens/dialogs/DialogModal.brs) — the comparison strings come from `Const().button` (see [/components/utils/Constants.brs](/components/utils/Constants.brs)).
 ```
 {
    "message": {
@@ -180,12 +232,6 @@ The string passed to setMessage is assigned using data from [/components/data/me
    }
 }
 ```
-#### Note
-In order to use the dialog and messages library, each XML file requires a top level script assigned as follows:
-```
-<script type="text/brightscript" uri="pkg:/components/utils/Messages.brs" />
-```
-
 <br/><br/>
 ## Resources
 * Examples and other Roku libraries


### PR DESCRIPTION
## Summary

Documentation-only PR. Brings the README in line with everything the audit added (Logger, Constants, BaseScreen lifecycle hooks) and corrects a handful of drift items that pre-dated the audit.

**Net: +64 / -18 lines, 1 file.**

## New documentation

### Logging section (under Console & Debugging)
Covers the four `logLevel` functions, output format, and the `m.global.devLogging` flag. Includes a small table of when each level prints.

### Constants subsection (under Configuration)
Explains the `Const()` AA pattern with quick examples for each group (`button`, `key`, `path`, `beacon`) and links to the source for the full table.

### Screen Lifecycle Hooks subsection (under Node Management)
Documents the three hooks (`onScreenInit` / `onScreenVisible` / `onScreenHidden`), how override-by-redeclaration works in SceneGraph, and points at `LandingScreen` as the working example. This was the single biggest documentation gap — anyone writing a new screen had no idea these hooks existed.

## Corrections to existing sections

| What | Why |
|---|---|
| Minimum OS `9.4` → `10.0` | Aligns with the `minVersion` actually enforced by [requirements.json](components/data/requirements.json). |
| `.env_sample` → `.env-sample` | The repo's file is hyphenated, README had underscore. |
| Globals bullet list | Added `deeplink` (set from launch args) and `devLogging` (Logger suppression flag); tightened the existing `m.global.ui` line. |
| Setting screen focus | Clarified that `focusedNode` is declared on `BaseScreen`'s interface and is read by `removeHistory` to restore focus. |
| Node Management Note | Rewrote from "every XML needs a Screens.brs `<script>` tag" to the accurate model — BaseScreen-derived screens inherit every utility through XML inheritance. The only place to register new utilities is `BaseScreen.xml` (or `HomeScene.xml`). |
| Dialogs & Messages | Updated the button-customization blockquote to mention `Const().button`; removed the redundant "Note" at the bottom of the section (it duplicated the Node Management note with stale info). |

## What's *not* in this PR

- The `/docs/images/globals.png` screenshot was generated before `deeplink` and `devLogging` were added to the globals AA — it's now slightly out of date but I can't regenerate images. Mentioning here so it's on your radar if you want to refresh it.
- The next PR will tackle long inline `if/then` statements (separate concern from docs).

## Testing

Visual review only. No code changed.