### PR TITLE
Break long inline if/then statements into multi-line blocks

### DIFF
--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -8,7 +8,9 @@ sub init()
 end sub
 sub onTitleChange(obj)
     title = obj.getData()
-    if m.titlearea <> invalid and len(m.titlearea.primaryTitle) > 0 then m.titlearea.primaryTitle = ""
+    if m.titlearea <> invalid and len(m.titlearea.primaryTitle) > 0
+        m.titlearea.primaryTitle = ""
+    end if
     if title <> invalid and len(title) > 0 then m.titlearea.primaryTitle = title
 end sub
 sub onMessageChange(obj)
@@ -21,7 +23,9 @@ sub onMessageChange(obj)
 end sub
 sub onBulletTextChange(obj)
     bullets = obj.getData()
-    if m.bulletarea <> invalid and m.bulletarea.bulletText.count() > 0 then m.bulletarea.bulletText = []
+    if m.bulletarea <> invalid and m.bulletarea.bulletText.count() > 0
+        m.bulletarea.bulletText = []
+    end if
     if bullets = invalid or bullets.count() = 0 then return
     m.bulletarea.bulletText = bullets
     for each node in m.bulletarea.getChild(0).getChildren(-1, 0)
@@ -45,7 +49,11 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
     if key <> Const().key.back then return false
     dialogModal = getScreen("dialogModal")
-    if dialogModal = invalid or dialogModal.dialogInfo = invalid or dialogModal.dialogInfo.count() = 0 then return true
-    if dialogModal.dialogInfo.allowBack <> invalid and dialogModal.dialogInfo.allowBack then removeScreen(dialogModal)
+    if dialogModal = invalid or dialogModal.dialogInfo = invalid or dialogModal.dialogInfo.count() = 0
+        return true
+    end if
+    if dialogModal.dialogInfo.allowBack <> invalid and dialogModal.dialogInfo.allowBack
+        removeScreen(dialogModal)
+    end if
     return true
 end function

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -21,10 +21,26 @@ end sub
 sub populateDialogBox(obj)
     m.dialogInfo = obj.getData()
     if m.dialogInfo = invalid or m.dialogInfo.count() = 0 then return
-    if m.dialogInfo.title <> invalid and len(m.dialogInfo.title) > 0 then title = m.dialogInfo.title else title = ""
-    if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0 then message = m.dialogInfo.message else message = ""
-    if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0 then help = m.dialogInfo.help else help = []
-    if m.dialogInfo.buttons <> invalid and m.dialogInfo.buttons.count() > 0 then buttons = m.dialogInfo.buttons else buttons = []
+    if m.dialogInfo.title <> invalid and len(m.dialogInfo.title) > 0
+        title = m.dialogInfo.title
+    else
+        title = ""
+    end if
+    if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0
+        message = m.dialogInfo.message
+    else
+        message = ""
+    end if
+    if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0
+        help = m.dialogInfo.help
+    else
+        help = []
+    end if
+    if m.dialogInfo.buttons <> invalid and m.dialogInfo.buttons.count() > 0
+        buttons = m.dialogInfo.buttons
+    else
+        buttons = []
+    end if
     createDialogNode(title, message, help, buttons)
 end sub
 sub onButtonSelected(obj)

--- a/components/screens/landing/LandingScreen.brs
+++ b/components/screens/landing/LandingScreen.brs
@@ -39,9 +39,12 @@ sub setLabelList()
     m.labelList.translation = [labelListX, labelListY]
 
     ' theme the label list using the HomeScene palette
-    if m.top.getScene().selectorUri <> invalid then m.labelList.focusBitmapUri = m.top.getScene().selectorUri
-    m.labelList.color = m.top.getScene().palette.colors.primaryTextColor
-    m.labelList.focusedColor = m.top.getScene().palette.colors.primaryTextColor
+    scene = m.top.getScene()
+    if scene.selectorUri <> invalid
+        m.labelList.focusBitmapUri = scene.selectorUri
+    end if
+    m.labelList.color = scene.palette.colors.primaryTextColor
+    m.labelList.focusedColor = scene.palette.colors.primaryTextColor
 end sub
 sub onItemSelected(obj)
     itemIndex = obj.getData()

--- a/components/utils/History.brs
+++ b/components/utils/History.brs
@@ -9,7 +9,9 @@ function addHistory(node as object, showScreen as boolean, hidePrevScreen as boo
         if prevNode <> invalid then prevNode.visible = false
     end if
     if showScreen <> invalid then node.visible = showScreen
-    if addToStack <> invalid and addToStack and m.screenStack <> invalid then m.screenStack.push(node)
+    if addToStack <> invalid and addToStack and m.screenStack <> invalid
+        m.screenStack.push(node)
+    end if
     return m.top.appendChild(node)
 end function
 function removeHistory(node as object, showPrevScreen as boolean, removeFromStack as boolean) as boolean

--- a/components/utils/Themes.brs
+++ b/components/utils/Themes.brs
@@ -10,9 +10,15 @@ sub setTheme(args as boolean, theme = { "type": "dark", "color": "red" } as obje
         paletteNode.colors = themeColors.palette
         homeScene.palette = paletteNode
     end if
-    if themeColors.backgroundUri <> invalid then homeScene.backgroundUri = themeColors.backgroundUri
-    if themeColors.backgroundColor <> invalid then homeScene.backgroundColor = themeColors.backgroundColor
-    if themeColors.selectorUri <> invalid and len(themeColors.selectorUri) > 0 then homeScene.selectorUri = themeColors.selectorUri
+    if themeColors.backgroundUri <> invalid
+        homeScene.backgroundUri = themeColors.backgroundUri
+    end if
+    if themeColors.backgroundColor <> invalid
+        homeScene.backgroundColor = themeColors.backgroundColor
+    end if
+    if themeColors.selectorUri <> invalid and len(themeColors.selectorUri) > 0
+        homeScene.selectorUri = themeColors.selectorUri
+    end if
 end sub
 function getThemeFromRegistry() as object
     theme = invalid

--- a/source/Main.brs
+++ b/source/Main.brs
@@ -83,7 +83,7 @@ function setDeviceInfo()
     ' create HDMI info object
     hdmiInfo = createObject("roHdmiStatus")
     ' check for an active version of hdcp or a device type of "TV" - all others refer to a set top box
-    if len(hdmiInfo.getHdcpVersion()) > 0 or deviceInfo.getModelType() = "TV" then hdcpStatus = true else hdcpStatus = false
+    hdcpStatus = len(hdmiInfo.getHdcpVersion()) > 0 or deviceInfo.getModelType() = "TV"
     ' get OS version
     os = deviceInfo.getOSVersion().major + "." + deviceInfo.getOSVersion().minor
     ' determine if device will return internet status


### PR DESCRIPTION
## Summary

Style sweep. Every inline `if ... then ...` statement at **100 characters or more** is now expressed as a multi-line `if ... end if` block. Lines under 100 chars are left inline.

**Net: +51 / -16 lines across 6 files. Zero behavior change.**

## Lines broken (sorted by original length)

| Length | File | Pattern |
|---:|---|---|
| 131 | `Themes.brs` `selectorUri` | inline assignment with 2-clause AND |
| 129 | `DialogModal.brs` `buttons` | `then X else Y` defaulter |
| 126 | `DialogModal.brs` `message` | same |
| 124 | `Main.brs` `hdcp` | `then true else false` — see special case |
| 119 | `BaseDialog.brs` `return true` | 3-clause OR guard |
| 118 | `BaseDialog.brs` `removeScreen` | 2-clause AND check |
| 116 | `DialogModal.brs` `title` | defaulter |
| 114 | `DialogModal.brs` `help` | defaulter |
| 109 | `LandingScreen.brs` `focusBitmapUri` | + repeated `m.top.getScene()` — see special case |
| 106 | `Themes.brs` `backgroundColor` | inline assignment |
| 104 | `BaseDialog.brs` `bulletText = []` | 2-clause AND reset |
| 102 | `History.brs` `screenStack.push` | 3-clause AND push |
| 102 | `BaseDialog.brs` `primaryTitle = ""` | 2-clause AND reset |
| 100 | `Themes.brs` `backgroundUri` | inline assignment |

## Special cases

### `Main.brs` hdcp — boolean expression instead of multi-line if/else
The original was a "ternary-style" `if ... then true else false`. Converting to a multi-line if/else would have been four lines for a value that's just the condition itself:

```brs
hdcpStatus = len(hdmiInfo.getHdcpVersion()) > 0 or deviceInfo.getModelType() = "TV"
```

Cleaner outcome, same semantics.

### `LandingScreen.brs setLabelList` — cached `m.top.getScene()`
The three lines after the "theme the label list" comment all called `m.top.getScene()` — once in the condition and twice for color assignments. Pulled into a local `scene` variable so all three lines shorten as a side benefit:

```brs
scene = m.top.getScene()
if scene.selectorUri <> invalid
    m.labelList.focusBitmapUri = scene.selectorUri
end if
m.labelList.color = scene.palette.colors.primaryTextColor
m.labelList.focusedColor = scene.palette.colors.primaryTextColor
```

## What's left inline (below threshold)

| Length | File | Note |
|---:|---|---|
| 95 | `Themes.brs` `reg.readMulti` | clean as one line |
| 93 | `Messages.brs` `message.key = X` | inside for-loop, body is a single return |
| 92 | `BaseDialog.brs` `messagetext.text = ""` | reset twin to title/bullet — left inline because under threshold |
| 80–88 | various | comfortably short |

## Note on `BaseDialog.onTitleChange` consistency

Within `onTitleChange`, the reset line (102 chars) is now multi-line but the set line (80 chars) is still inline. That's intentional — the threshold cut between them — but if you'd rather see the cluster match perfectly, easy follow-up.