### PR TITLE
Add hasValue/valueOr helpers and apply across the codebase

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -11,17 +11,11 @@ sub startApp()
     addScreen("LandingScreen", "landingScreen")
 end sub
 function addNode(params as object) as object
-    if params = invalid or params.count() = 0 then return invalid
-    if params.screenName = invalid or len(params.screenName) = 0 then return invalid
+    if not hasValue(params) then return invalid
+    if not hasValue(params.screenName) then return invalid
     node = createObject("roSGNode", params.screenName)
     if node = invalid then return invalid
-    if node.id = invalid or len(node.id) = 0
-        if params.screenId <> invalid and len(params.screenId) > 0
-            node.id = params.screenId
-        else
-            node.id = params.screenName
-        end if
-    end if
+    if not hasValue(node.id) then node.id = valueOr(params.screenId, params.screenName)
     if addHistory(node, params.showScreen, params.hidePrevScreen, params.addToStack)
         node.setFocus(true)
     else
@@ -36,7 +30,7 @@ sub removeNode(params as object)
 end sub
 sub onMessage(obj)
     message = obj.getData()
-    if message = invalid or len(message) = 0 then return
+    if not hasValue(message) then return
     ' guard against an unknown key so the dialog code isn't called with invalid
     params = getMessage(message)
     if params = invalid

--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -1,5 +1,5 @@
 sub init()
-    if m.top.id = invalid or len(m.top.id) = 0 then m.top.id = "baseDialog"
+    if not hasValue(m.top.id) then m.top.id = "baseDialog"
     m.titlearea = m.top.findNode("titleArea")
     m.messagetext = m.top.findNode("messageText")
     m.bulletarea = m.top.findNode("bulletArea")
@@ -7,15 +7,15 @@ sub init()
 end sub
 sub onTitleChange(obj)
     title = obj.getData()
-    if m.titlearea <> invalid and len(m.titlearea.primaryTitle) > 0
+    if m.titlearea <> invalid and hasValue(m.titlearea.primaryTitle)
         m.titlearea.primaryTitle = ""
     end if
-    if title <> invalid and len(title) > 0 then m.titlearea.primaryTitle = title
+    if hasValue(title) then m.titlearea.primaryTitle = title
 end sub
 sub onMessageChange(obj)
     message = obj.getData()
-    if m.messagetext <> invalid and len(m.messagetext.text) > 0 then m.messagetext.text = ""
-    if message = invalid or len(message) = 0 then return
+    if m.messagetext <> invalid and hasValue(m.messagetext.text) then m.messagetext.text = ""
+    if not hasValue(message) then return
     m.messagetext.text = message
     m.messagetext.namedTextStyle = "bold"
     m.messagetext.getChild(0).font.size = 32
@@ -25,7 +25,7 @@ sub onBulletTextChange(obj)
     if m.bulletarea <> invalid and m.bulletarea.bulletText.count() > 0
         m.bulletarea.bulletText = []
     end if
-    if bullets = invalid or bullets.count() = 0 then return
+    if not hasValue(bullets) then return
     m.bulletarea.bulletText = bullets
     for each node in m.bulletarea.getChild(0).getChildren(-1, 0)
         node.update({ "color": m.top.getScene().palette.colors.dialogBulletTextColor }, true)
@@ -37,7 +37,7 @@ sub onButtonChange(obj)
     if m.buttonarea <> invalid and m.buttonarea.getChildCount() > 0
         m.buttonarea.removeChildren(m.buttonarea.getChildren(-1, 0))
     end if
-    if buttons = invalid or buttons.count() = 0 then return
+    if not hasValue(buttons) then return
     for each button in buttons
         buttonNode = createObject("roSGNode", "StdDlgButton")
         buttonNode.text = button
@@ -48,11 +48,7 @@ function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
     if key <> Const().key.back then return false
     dialogModal = getScreen("dialogModal")
-    if dialogModal = invalid or dialogModal.dialogInfo = invalid or dialogModal.dialogInfo.count() = 0
-        return true
-    end if
-    if dialogModal.dialogInfo.allowBack <> invalid and dialogModal.dialogInfo.allowBack
-        removeScreen(dialogModal)
-    end if
+    if dialogModal = invalid or not hasValue(dialogModal.dialogInfo) then return true
+    if dialogModal.dialogInfo.allowBack = true then removeScreen(dialogModal)
     return true
 end function

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -20,27 +20,11 @@ sub createDialogNode(title = "" as string, message = "" as string, help = [] as 
 end sub
 sub populateDialogBox(obj)
     m.dialogInfo = obj.getData()
-    if m.dialogInfo = invalid or m.dialogInfo.count() = 0 then return
-    if m.dialogInfo.title <> invalid and len(m.dialogInfo.title) > 0
-        title = m.dialogInfo.title
-    else
-        title = ""
-    end if
-    if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0
-        message = m.dialogInfo.message
-    else
-        message = ""
-    end if
-    if m.dialogInfo.help <> invalid and m.dialogInfo.help.count() > 0
-        help = m.dialogInfo.help
-    else
-        help = []
-    end if
-    if m.dialogInfo.buttons <> invalid and m.dialogInfo.buttons.count() > 0
-        buttons = m.dialogInfo.buttons
-    else
-        buttons = []
-    end if
+    if not hasValue(m.dialogInfo) then return
+    title = valueOr(m.dialogInfo.title, "")
+    message = valueOr(m.dialogInfo.message, "")
+    help = valueOr(m.dialogInfo.help, [])
+    buttons = valueOr(m.dialogInfo.buttons, [])
     createDialogNode(title, message, help, buttons)
 end sub
 sub onButtonSelected(obj)
@@ -48,7 +32,7 @@ sub onButtonSelected(obj)
     buttonSelected = m.dialogNode.buttons[buttonIndex]
     button = Const().button
     if buttonSelected = button.okay or buttonSelected = button.yes
-        if m.dialogInfo.exitApp <> invalid and m.dialogInfo.exitApp
+        if m.dialogInfo.exitApp = true
             m.top.getScene().exitApp = true
         else
             removeBaseDialog()

--- a/components/utils/General.brs
+++ b/components/utils/General.brs
@@ -1,3 +1,19 @@
+' ---- value helpers ----
+' true when x is non-invalid and (for strings / arrays / AAs) non-empty.
+' Numbers, booleans, and nodes only get the non-invalid check.
+function hasValue(x as dynamic) as boolean
+    if x = invalid then return false
+    valueType = type(x)
+    if valueType = "String" or valueType = "roString" then return len(x) > 0
+    if valueType = "roArray" or valueType = "roAssociativeArray" then return x.count() > 0
+    return true
+end function
+function valueOr(x as dynamic, defaultValue as dynamic) as dynamic
+    if hasValue(x) then return x
+    return defaultValue
+end function
+
+' ---- Roku certification beacons ----
 sub dialogInit(node = m.top.getScene())
     ' Roku certification requires this to indicate a modal requires the users attention
     if not node.appLoaded then node.signalBeacon(Const().beacon.dialogInitiate)

--- a/components/utils/History.brs
+++ b/components/utils/History.brs
@@ -4,23 +4,23 @@ sub initScreenStack()
 end sub
 function addHistory(node as object, showScreen as boolean, hidePrevScreen as boolean, addToStack as boolean) as boolean
     if node = invalid then return false
-    if hidePrevScreen <> invalid and hidePrevScreen and m.screenStack <> invalid and m.screenStack.count() > 0
+    if hidePrevScreen = true and hasValue(m.screenStack)
         prevNode = m.screenStack.peek()
         if prevNode <> invalid then prevNode.visible = false
     end if
     if showScreen <> invalid then node.visible = showScreen
-    if addToStack <> invalid and addToStack and m.screenStack <> invalid
+    if addToStack = true and m.screenStack <> invalid
         m.screenStack.push(node)
     end if
     return m.top.appendChild(node)
 end function
 function removeHistory(node as object, showPrevScreen as boolean, removeFromStack as boolean) as boolean
     if node = invalid then return false
-    if m.screenStack <> invalid and m.screenStack.count() > 0
-        if removeFromStack <> invalid and removeFromStack
+    if hasValue(m.screenStack)
+        if removeFromStack = true
             if m.screenStack.peek().isSameNode(node) then m.screenStack.pop()
         end if
-        if m.screenStack.count() > 0 and showPrevScreen <> invalid and showPrevScreen
+        if m.screenStack.count() > 0 and showPrevScreen = true
             prevNode = m.screenStack.peek()
             if prevNode <> invalid
                 if not prevNode.visible then prevNode.visible = true
@@ -32,7 +32,7 @@ function removeHistory(node as object, showPrevScreen as boolean, removeFromStac
     return m.top.removeChild(node)
 end function
 sub getHistory()
-    if m.screenStack = invalid or m.screenStack.count() = 0
+    if not hasValue(m.screenStack)
         logDebug("screen stack is empty", "History.brs")
         return
     end if

--- a/components/utils/Messages.brs
+++ b/components/utils/Messages.brs
@@ -7,7 +7,7 @@ sub createDialog(params = {} as object)
         logError("message is empty", "Messages.brs")
         return
     end if
-    if params.title = invalid or len(params.title) = 0
+    if not hasValue(params.title)
         logError("message title is required; contents: " + FormatJson(params), "Messages.brs")
         return
     end if

--- a/components/utils/Screens.brs
+++ b/components/utils/Screens.brs
@@ -1,5 +1,5 @@
 function getScreen(screenId as string, showScreen = false as boolean)
-    if screenId = invalid or len(screenId) = 0
+    if not hasValue(screenId)
         logError("invalid screenId passed to getScreen", "Screens.brs")
         return invalid
     end if
@@ -12,14 +12,14 @@ function getScreen(screenId as string, showScreen = false as boolean)
     return node
 end function
 function screenExists(screenId as string) as boolean
-    if screenId = invalid or len(screenId) = 0
+    if not hasValue(screenId)
         logError("invalid screenId passed to screenExists", "Screens.brs")
         return false
     end if
     return getScreen(screenId) <> invalid
 end function
 function addScreen(screenName as string, screenId = invalid as string, showScreen = true as boolean, hidePrevScreen = true as boolean, addToStack = true as boolean) as object
-    if screenId = invalid or screenId.len() = 0
+    if not hasValue(screenId)
         screenId = screenName
         logInfo("no screen id assigned for " + screenName + " node; using " + screenName + " as id", "Screens.brs")
     end if

--- a/components/utils/Themes.brs
+++ b/components/utils/Themes.brs
@@ -5,7 +5,7 @@ sub setTheme(args as boolean, theme = { "type": "dark", "color": "red" } as obje
     themeColors = getTheme(theme)
     if themeColors = invalid then return
     homeScene = m.top.getScene()
-    if themeColors.palette <> invalid and themeColors.palette.count() > 0
+    if hasValue(themeColors.palette)
         paletteNode = CreateObject("roSGNode", "RSGPalette")
         paletteNode.colors = themeColors.palette
         homeScene.palette = paletteNode
@@ -16,7 +16,7 @@ sub setTheme(args as boolean, theme = { "type": "dark", "color": "red" } as obje
     if themeColors.backgroundColor <> invalid
         homeScene.backgroundColor = themeColors.backgroundColor
     end if
-    if themeColors.selectorUri <> invalid and len(themeColors.selectorUri) > 0
+    if hasValue(themeColors.selectorUri)
         homeScene.selectorUri = themeColors.selectorUri
     end if
 end sub
@@ -32,7 +32,7 @@ function getTheme(theme as object) as dynamic
     json = ParseJson(themefile)
     if json = invalid then return invalid
     themeType = json[theme.type]
-    if themeType = invalid or themeType.count() = 0 then return invalid
+    if not hasValue(themeType) then return invalid
     for each color in themeType
         if color[theme.color] <> invalid then return color[theme.color]
     end for


### PR DESCRIPTION
## Summary

Introduces two small value-checking helpers in [General.brs](components/utils/General.brs) and migrates ~20 sites across the codebase that were doing the omnipresent `<> invalid and len/count > 0` pattern.

**Net: -10 lines across 8 files.** The readability lift is larger than the line count — most replacements collapse two-clause guards into one identifier.

## The helpers

```brs
' true when x is non-invalid and (for strings / arrays / AAs) non-empty.
' Numbers, booleans, and nodes only get the non-invalid check.
function hasValue(x as dynamic) as boolean
    if x = invalid then return false
    valueType = type(x)
    if valueType = "String" or valueType = "roString" then return len(x) > 0
    if valueType = "roArray" or valueType = "roAssociativeArray" then return x.count() > 0
    return true
end function
function valueOr(x as dynamic, defaultValue as dynamic) as dynamic
    if hasValue(x) then return x
    return defaultValue
end function
```

Placed in `General.brs` under a `' ---- value helpers ----` section, with the existing beacon helpers re-grouped under `' ---- Roku certification beacons ----`.

## Headline win: `DialogModal.populateDialogBox`

**Before:**
```brs
if m.dialogInfo.title <> invalid and len(m.dialogInfo.title) > 0
    title = m.dialogInfo.title
else
    title = ""
end if
if m.dialogInfo.message <> invalid and len(m.dialogInfo.message) > 0
    message = m.dialogInfo.message
else
    message = ""
end if
... (same for help and buttons)
```

**After:**
```brs
title = valueOr(m.dialogInfo.title, "")
message = valueOr(m.dialogInfo.message, "")
help = valueOr(m.dialogInfo.help, [])
buttons = valueOr(m.dialogInfo.buttons, [])
```

20 lines → 4.

## All migrated sites

| File | Sites | Notes |
|---|---:|---|
| `HomeScene.brs` | 3 | including `node.id = valueOr(params.screenId, params.screenName)` |
| `BaseDialog.brs` | 6 | the four `onChange` handlers + init + onKeyEvent |
| `DialogModal.brs` | 3 | including the 4-defaulter cluster above |
| `Screens.brs` | 3 | `getScreen`, `screenExists`, `addScreen` id guards |
| `History.brs` | 3 | screen-stack predicate checks |
| `Themes.brs` | 3 | `palette`, `selectorUri`, `themeType` checks |
| `Messages.brs` | 1 | the `params.title` check |

## Bonus: `<> invalid and X` → `X = true`

Several sites had `if X.field <> invalid and X.field` (i.e. "is this boolean field set to true?"). Replaced with `X.field = true` — same semantics (invalid ≠ true → false) but shorter. Affected:
- `History.addHistory` — `hidePrevScreen`, `addToStack`
- `History.removeHistory` — `removeFromStack`, `showPrevScreen`
- `BaseDialog.onKeyEvent` — `allowBack`
- `DialogModal.onButtonSelected` — `exitApp`

## Intentionally NOT migrated

A few sites combine type detection with the non-empty check in a way that hasValue can't cleanly replace:

- `Screens.removeScreen`, `Screens.setFocus`: `type(X) = "String" and len(X) > 0` — keeps the type narrowing visible
- `BaseDialog.onBulletTextChange`, `onButtonChange` resets: `X.bulletText.count() > 0` and `X.getChildCount() > 0` — calling methods on a known-non-invalid node; hasValue would work but adds a layer of indirection over a one-line direct method call

## Testing

Visual review only. All sites preserve semantics. The biggest behavior surface here is `m.dialogInfo.exitApp = true` (was `<> invalid and X`) and the four similar boolean-field checks — verified mentally that `invalid = true` evaluates to false in BrightScript so failing cases (missing field) still produce the same skip.

If you sideload, the natural smoke test is: trigger an exit dialog and confirm pressing YES exits the channel.