### PR TITLE
Stop screenExists from emitting a false-alarm warn

### DIFF
--- a/components/utils/Screens.brs
+++ b/components/utils/Screens.brs
@@ -16,7 +16,9 @@ function screenExists(screenId as string) as boolean
         logError("invalid screenId passed to screenExists", "Screens.brs")
         return false
     end if
-    return getScreen(screenId) <> invalid
+    ' direct findNode avoids the "not found" warn that getScreen emits on miss;
+    ' callers using screenExists are intentionally probing for an unknown screen
+    return m.top.getScene().findNode(screenId) <> invalid
 end function
 function addScreen(screenName as string, screenId = invalid as string, showScreen = true as boolean, hidePrevScreen = true as boolean, addToStack = true as boolean) as object
     if not hasValue(screenId)


### PR DESCRIPTION
## Summary

Tiny fix. `screenExists()` was indirectly logging a `logWarn("<id> was not found")` on every probe — including the legitimate "does this screen exist yet?" check inside `createDialog`. Now silent.

**Net: +3 / -1 lines, 1 file.**

## The bug

`screenExists` delegated to `getScreen`:

```brs
function screenExists(screenId as string) as boolean
    if not hasValue(screenId)
        logError("invalid screenId passed to screenExists", "Screens.brs")
        return false
    end if
    return getScreen(screenId) <> invalid
end function
```

`getScreen` correctly emits `logWarn(screenId + " was not found", "Screens.brs")` on a miss — but that's the wrong log level for a *probe*. Every call to `Messages.createDialog`:

```brs
if screenExists("dialogModal")
    screen = getScreen("dialogModal")
else
    screen = addScreen("DialogModal", "dialogModal", true, false)
end if
```

…hit the warn on the *first* dialog the channel ever showed, because the DialogModal screen didn't exist yet. False alarm.

## The fix

Switched `screenExists` to call `findNode` directly:

```brs
return m.top.getScene().findNode(screenId) <> invalid
```

`getScreen` keeps its warn — callers that actually want to *fetch* a screen still benefit from the diagnostic when the screen is missing. They're answering different questions:

| Function | Question | Behavior on miss |
|---|---|---|
| `getScreen` | "fetch this screen, optionally make it visible" | warns then returns invalid |
| `screenExists` | "does this screen exist?" | silently returns false |

## Testing

Sideload + open any dialog. The `[WARN] dialogModal was not found (Screens.brs)` line that used to appear before the dialog rendered should be gone.