### PR TITLE
Normalize BaseDialog m.* references to camelCase

### DIFF
--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -1,47 +1,47 @@
 sub init()
     if not hasValue(m.top.id) then m.top.id = "baseDialog"
-    m.titlearea = m.top.findNode("titleArea")
-    m.messagetext = m.top.findNode("messageText")
-    m.bulletarea = m.top.findNode("bulletArea")
-    m.buttonarea = m.top.findNode("buttonArea")
+    m.titleArea = m.top.findNode("titleArea")
+    m.messageText = m.top.findNode("messageText")
+    m.bulletArea = m.top.findNode("bulletArea")
+    m.buttonArea = m.top.findNode("buttonArea")
 end sub
 sub onTitleChange(obj)
     title = obj.getData()
-    if m.titlearea <> invalid and hasValue(m.titlearea.primaryTitle)
-        m.titlearea.primaryTitle = ""
+    if m.titleArea <> invalid and hasValue(m.titleArea.primaryTitle)
+        m.titleArea.primaryTitle = ""
     end if
-    if hasValue(title) then m.titlearea.primaryTitle = title
+    if hasValue(title) then m.titleArea.primaryTitle = title
 end sub
 sub onMessageChange(obj)
     message = obj.getData()
-    if m.messagetext <> invalid and hasValue(m.messagetext.text) then m.messagetext.text = ""
+    if m.messageText <> invalid and hasValue(m.messageText.text) then m.messageText.text = ""
     if not hasValue(message) then return
-    m.messagetext.text = message
-    m.messagetext.namedTextStyle = "bold"
-    m.messagetext.getChild(0).font.size = 32
+    m.messageText.text = message
+    m.messageText.namedTextStyle = "bold"
+    m.messageText.getChild(0).font.size = 32
 end sub
 sub onBulletTextChange(obj)
     bullets = obj.getData()
-    if m.bulletarea <> invalid and m.bulletarea.bulletText.count() > 0
-        m.bulletarea.bulletText = []
+    if m.bulletArea <> invalid and m.bulletArea.bulletText.count() > 0
+        m.bulletArea.bulletText = []
     end if
     if not hasValue(bullets) then return
-    m.bulletarea.bulletText = bullets
-    for each node in m.bulletarea.getChild(0).getChildren(-1, 0)
+    m.bulletArea.bulletText = bullets
+    for each node in m.bulletArea.getChild(0).getChildren(-1, 0)
         node.update({ "color": m.top.getScene().palette.colors.dialogBulletTextColor }, true)
         node.font.size = 29
     end for
 end sub
 sub onButtonChange(obj)
     buttons = obj.getData()
-    if m.buttonarea <> invalid and m.buttonarea.getChildCount() > 0
-        m.buttonarea.removeChildren(m.buttonarea.getChildren(-1, 0))
+    if m.buttonArea <> invalid and m.buttonArea.getChildCount() > 0
+        m.buttonArea.removeChildren(m.buttonArea.getChildren(-1, 0))
     end if
     if not hasValue(buttons) then return
     for each button in buttons
         buttonNode = createObject("roSGNode", "StdDlgButton")
         buttonNode.text = button
-        m.buttonarea.appendChild(buttonNode)
+        m.buttonArea.appendChild(buttonNode)
     end for
 end sub
 function onKeyEvent(key as string, press as boolean) as boolean


### PR DESCRIPTION
## Summary

Pure rename. The four local node references in `BaseDialog.brs` were the last all-lowercase identifiers in the codebase:

| Before | After |
|---|---|
| `m.titlearea` | `m.titleArea` |
| `m.messagetext` | `m.messageText` |
| `m.bulletarea` | `m.bulletArea` |
| `m.buttonarea` | `m.buttonArea` |

Everything else — XML interface fields, `findNode()` string args, every other `m.*` reference in the codebase — was already camelCase. Now consistent.

**Net: +18 / -18 lines, 1 file, zero behavior change.**

## Verification

```
$ grep -rn "m\.titlearea\|m\.messagetext\|m\.bulletarea\|m\.buttonarea" components --include="*.brs"
(empty)
```

## Testing

Visual review only. Rename is internal to BaseDialog.brs — none of these identifiers cross a component boundary.