### PR TITLE
Cache root Scene as m.scene; replace m.top.getScene() everywhere

### DIFF
--- a/components/HomeScene.brs
+++ b/components/HomeScene.brs
@@ -1,4 +1,6 @@
 sub init()
+    ' cache the root Scene; util scripts use m.scene instead of m.top.getScene()
+    m.scene = m.top.getScene()
     ' setTheme(true) applies default; pass {"type":"light","color":"red"} matching /components/data/themes.json to override
     setTheme(true)
     ' setRequirements(true) enforces /components/data/requirements.json; bump minVersion there to test the OS-update error path

--- a/components/screens/base/BaseScreen.brs
+++ b/components/screens/base/BaseScreen.brs
@@ -1,4 +1,6 @@
 sub init()
+    ' cache the root Scene; subclasses and util scripts use m.scene instead of m.top.getScene()
+    m.scene = m.top.getScene()
     ' hide until shown; subclasses override the hooks below, not init()
     m.top.visible = false
     m.top.observeField("visible", "baseScreenOnVisibleChange")

--- a/components/screens/dialogs/BaseDialog.brs
+++ b/components/screens/dialogs/BaseDialog.brs
@@ -1,4 +1,6 @@
 sub init()
+    ' cache the root Scene; util scripts use m.scene instead of m.top.getScene()
+    m.scene = m.top.getScene()
     if not hasValue(m.top.id) then m.top.id = "baseDialog"
     m.titleArea = m.top.findNode("titleArea")
     m.messageText = m.top.findNode("messageText")
@@ -27,8 +29,9 @@ sub onBulletTextChange(obj)
     end if
     if not hasValue(bullets) then return
     m.bulletArea.bulletText = bullets
+    bulletColor = m.scene.palette.colors.dialogBulletTextColor
     for each node in m.bulletArea.getChild(0).getChildren(-1, 0)
-        node.update({ "color": m.top.getScene().palette.colors.dialogBulletTextColor }, true)
+        node.update({ "color": bulletColor }, true)
         node.font.size = 29
     end for
 end sub

--- a/components/screens/dialogs/DialogModal.brs
+++ b/components/screens/dialogs/DialogModal.brs
@@ -33,7 +33,7 @@ sub onButtonSelected(obj)
     button = Const().button
     if buttonSelected = button.okay or buttonSelected = button.yes
         if m.dialogInfo.exitApp = true
-            m.top.getScene().exitApp = true
+            m.scene.exitApp = true
         else
             removeBaseDialog()
         end if

--- a/components/screens/landing/LandingScreen.brs
+++ b/components/screens/landing/LandingScreen.brs
@@ -15,7 +15,7 @@ sub setLandingTitle()
     ' tr() is optional — pass plain strings if you don't need translations
     m.landingTitle.text = tr("Welcome To The Landing Screen")
     m.landingTitle.font.size = 62
-    m.landingTitle.color = m.top.getScene().palette.colors.primaryTextColor
+    m.landingTitle.color = m.scene.palette.colors.primaryTextColor
 end sub
 sub populateLabelList()
     ' tr() is optional — pass plain strings if you don't need translations
@@ -39,24 +39,23 @@ sub setLabelList()
     m.labelList.translation = [labelListX, labelListY]
 
     ' theme the label list using the HomeScene palette
-    scene = m.top.getScene()
-    if scene.selectorUri <> invalid
-        m.labelList.focusBitmapUri = scene.selectorUri
+    if m.scene.selectorUri <> invalid
+        m.labelList.focusBitmapUri = m.scene.selectorUri
     end if
-    m.labelList.color = scene.palette.colors.primaryTextColor
-    m.labelList.focusedColor = scene.palette.colors.primaryTextColor
+    m.labelList.color = m.scene.palette.colors.primaryTextColor
+    m.labelList.focusedColor = m.scene.palette.colors.primaryTextColor
 end sub
 sub onItemSelected(obj)
     itemIndex = obj.getData()
     itemSelected = m.labelList.content.getChild(itemIndex)
-    if itemSelected.title = tr("Exit") then m.top.getScene().message = "exit"
+    if itemSelected.title = tr("Exit") then m.scene.message = "exit"
 end sub
 ' capture key events from remote control
 function onKeyEvent(key as string, press as boolean) as boolean
     if not press then return false
     keys = Const().key
     if key = keys.back
-        m.top.getScene().message = "exit"
+        m.scene.message = "exit"
         return true
     end if
     if key = keys.up

--- a/components/utils/General.brs
+++ b/components/utils/General.brs
@@ -14,15 +14,15 @@ function valueOr(x as dynamic, defaultValue as dynamic) as dynamic
 end function
 
 ' ---- Roku certification beacons ----
-sub dialogInit(node = m.top.getScene())
+sub dialogInit(node = m.scene)
     ' Roku certification requires this to indicate a modal requires the users attention
     if not node.appLoaded then node.signalBeacon(Const().beacon.dialogInitiate)
 end sub
-sub dialogComplete(node = m.top.getScene())
+sub dialogComplete(node = m.scene)
     ' Roku certification requires this to indicate the modal is closed
     if not node.appLoaded then node.signalBeacon(Const().beacon.dialogComplete)
 end sub
-sub appLoaded(node = m.top.getScene())
+sub appLoaded(node = m.scene)
     if not node.appLoaded
         node.appLoaded = true
         ' Roku certification requires this to indicate the app is finished loading

--- a/components/utils/Requirements.brs
+++ b/components/utils/Requirements.brs
@@ -20,7 +20,7 @@ function checkRequirements(requirements as object) as boolean
             deviceReady = getRequirement(requirement)
             if (deviceReady <> invalid)
                 if (not deviceReady and requirement.value["showError"] <> invalid and requirement.value["showError"])
-                    m.top.getScene().message = requirement.key
+                    m.scene.message = requirement.key
                     exit for
                 end if
             else

--- a/components/utils/Screens.brs
+++ b/components/utils/Screens.brs
@@ -3,7 +3,7 @@ function getScreen(screenId as string, showScreen = false as boolean)
         logError("invalid screenId passed to getScreen", "Screens.brs")
         return invalid
     end if
-    node = m.top.getScene().findNode(screenId)
+    node = m.scene.findNode(screenId)
     if node = invalid
         logWarn(screenId + " was not found", "Screens.brs")
         return invalid
@@ -18,7 +18,7 @@ function screenExists(screenId as string) as boolean
     end if
     ' direct findNode avoids the "not found" warn that getScreen emits on miss;
     ' callers using screenExists are intentionally probing for an unknown screen
-    return m.top.getScene().findNode(screenId) <> invalid
+    return m.scene.findNode(screenId) <> invalid
 end function
 function addScreen(screenName as string, screenId = invalid as string, showScreen = true as boolean, hidePrevScreen = true as boolean, addToStack = true as boolean) as object
     if not hasValue(screenId)
@@ -29,7 +29,7 @@ function addScreen(screenName as string, screenId = invalid as string, showScree
         logError("id '" + screenId + "' already assigned to another screen node", "Screens.brs")
         return invalid
     end if
-    return m.top.getScene().callFunc("addNode", {"screenName": screenName, "showScreen": showScreen, "screenId": screenId, "hidePrevScreen": hidePrevScreen, "addToStack": addToStack})
+    return m.scene.callFunc("addNode", {"screenName": screenName, "showScreen": showScreen, "screenId": screenId, "hidePrevScreen": hidePrevScreen, "addToStack": addToStack})
 end function
 sub removeScreen(screen = invalid as dynamic, showPrevScreen = true as boolean, removeFromStack = true as boolean)
     if screen = invalid then return
@@ -40,11 +40,11 @@ sub removeScreen(screen = invalid as dynamic, showPrevScreen = true as boolean, 
         node = getScreen(screen)
     end if
     if node = invalid then return
-    m.top.getScene().callFunc("removeNode", {"node": node, "showPrevScreen": showPrevScreen, "removeFromStack": removeFromStack})
+    m.scene.callFunc("removeNode", {"node": node, "showPrevScreen": showPrevScreen, "removeFromStack": removeFromStack})
 end sub
 function getAllScreens() as dynamic
     ' create a variable to store all of the child nodes from HomeScene
-    screenArray = m.top.getScene().getChildren(-1, 0)
+    screenArray = m.scene.getChildren(-1, 0)
     ' check that the screen array is valid and has an item count of greater than zero
     if (screenArray <> invalid and screenArray.count() > 0)
         ' return the screen array

--- a/components/utils/Themes.brs
+++ b/components/utils/Themes.brs
@@ -4,20 +4,19 @@ sub setTheme(args as boolean, theme = { "type": "dark", "color": "red" } as obje
     if prevTheme <> invalid then theme = prevTheme
     themeColors = getTheme(theme)
     if themeColors = invalid then return
-    homeScene = m.top.getScene()
     if hasValue(themeColors.palette)
         paletteNode = CreateObject("roSGNode", "RSGPalette")
         paletteNode.colors = themeColors.palette
-        homeScene.palette = paletteNode
+        m.scene.palette = paletteNode
     end if
     if themeColors.backgroundUri <> invalid
-        homeScene.backgroundUri = themeColors.backgroundUri
+        m.scene.backgroundUri = themeColors.backgroundUri
     end if
     if themeColors.backgroundColor <> invalid
-        homeScene.backgroundColor = themeColors.backgroundColor
+        m.scene.backgroundColor = themeColors.backgroundColor
     end if
     if hasValue(themeColors.selectorUri)
-        homeScene.selectorUri = themeColors.selectorUri
+        m.scene.selectorUri = themeColors.selectorUri
     end if
 end sub
 function getThemeFromRegistry() as object


### PR DESCRIPTION
## Summary

Promotes `m.top.getScene()` to `m.scene`, cached once in the init() of each component that hosts runtime code. Every util-script call site and component reference is migrated.

**Net: +29 / -24 lines across 9 files.** Reads shorten everywhere; per-call cost of `getScene()` drops to zero.

## The pattern

Three `init()`s now stash the Scene reference:

```brs
sub init()
    ' cache the root Scene; util scripts use m.scene instead of m.top.getScene()
    m.scene = m.top.getScene()
    ...
end sub
```

- [`BaseScreen.brs`](components/screens/base/BaseScreen.brs) — covers `LandingScreen`, `DialogModal`, and any future BaseScreen-derived component
- [`HomeScene.brs`](components/HomeScene.brs) — for `HomeScene` itself
- [`BaseDialog.brs`](components/screens/dialogs/BaseDialog.brs) — for the `StandardDialog`-derived `BaseDialog`

Util scripts (`Screens`, `Requirements`, `Themes`, `General`) run with the calling component's `m`, so they pick up `m.scene` from whichever of the three initialized it.

## Migrated sites

| File | Sites | Notes |
|---|---:|---|
| `Screens.brs` | 5 | `findNode` × 2, `callFunc` × 2, `getChildren` × 1 |
| `Requirements.brs` | 1 | `m.scene.message = requirement.key` |
| `Themes.brs` | — | dropped the `homeScene = m.top.getScene()` local entirely; `m.scene.X` used directly across all four assignments |
| `General.brs` | 3 | `node = m.scene` default arg on `dialogInit`, `dialogComplete`, `appLoaded` |
| `DialogModal.brs` | 1 | `m.scene.exitApp = true` |
| `LandingScreen.brs` | 4 | dropped the `scene = m.top.getScene()` local in `setLabelList`; converted both `m.scene.message = "exit"` sites |
| `BaseDialog.brs` | 1 | inside the bullet for-loop |

## Special case: BaseDialog bullet loop

Was traversing `m.top.getScene().palette.colors.dialogBulletTextColor` on every iteration:

```brs
for each node in m.bulletArea.getChild(0).getChildren(-1, 0)
    node.update({ "color": m.top.getScene().palette.colors.dialogBulletTextColor }, true)
    node.font.size = 29
end for
```

Now caches the specific color outside the loop — even with `m.scene`, the full `m.scene.palette.colors.X` chain wasn't worth running per iteration:

```brs
bulletColor = m.scene.palette.colors.dialogBulletTextColor
for each node in m.bulletArea.getChild(0).getChildren(-1, 0)
    node.update({ "color": bulletColor }, true)
    node.font.size = 29
end for
```

## What's not in this PR

A README note about the `m.scene` convention. The init() comments explain it in-code; if you want the README's Node Management section to mention it explicitly, easy follow-up.

## Testing

Sideload smoke test:
- Open the channel → LandingScreen renders correctly with theme colors (verifies `m.scene.palette.colors.primaryTextColor` works in onScreenInit context).
- Press OK key with no selection → nothing crashes (verifies `m.scene.message = "exit"` path).
- Trigger any dialog → bullet text renders in the themed color (verifies `bulletColor = m.scene.palette.colors.dialogBulletTextColor` cache).
- Press YES on exit dialog → channel exits (verifies `m.scene.exitApp = true` in DialogModal).

If `m.scene` ever turns up `invalid` at runtime (i.e., a new component was added that doesn't extend BaseScreen/HomeScene/BaseDialog and didn't set `m.scene` in its own init), all of these would fail loudly. Current call graph is fully covered.