### PR TITLE
Polish Requirements.brs: fail-closed setAsBool, simpler shapes

### DIFF
--- a/components/utils/Requirements.brs
+++ b/components/utils/Requirements.brs
@@ -16,42 +16,32 @@ function checkRequirements(requirements as object) as boolean
     ' default to ready so empty or all-optional requirement sets pass the type contract
     deviceReady = true
     for each requirement in requirements.items()
-        if (requirement.value <> invalid and requirement.value["required"])
-            deviceReady = getRequirement(requirement)
-            if (deviceReady <> invalid)
-                if (not deviceReady and requirement.value["showError"] <> invalid and requirement.value["showError"])
-                    m.scene.message = requirement.key
-                    exit for
-                end if
-            else
-                deviceReady = true
-            end if
+        if requirement.value = invalid or requirement.value["required"] <> true then continue for
+        deviceReady = getRequirement(requirement)
+        if deviceReady = invalid
+            deviceReady = true
+        else if not deviceReady and requirement.value["showError"] = true
+            m.scene.message = requirement.key
+            exit for
         end if
     end for
     return deviceReady
 end function
 function getRequirement(requirement as object) as boolean
     v = m.global[requirement.key]
-    if (v = invalid)
-        return false
-    else if (type(v) = "roBoolean")
-        return v
-    else
-        return setAsBool(requirement, v)
-    end if
+    if v = invalid then return false
+    if type(v) = "roBoolean" then return v
+    return setAsBool(requirement, v)
 end function
-function setAsBool(requirement as object, v as dynamic)
-    if (requirement.key = "os")
-        return getMinOS(requirement, v)
-    else if (requirement.key = "model")
-        return getModel(requirement, v)
-    end if
+function setAsBool(requirement as object, v as dynamic) as boolean
+    if requirement.key = "os" then return getMinOS(requirement, v)
+    if requirement.key = "model" then return getModel(requirement, v)
+    ' fail closed on unknown keys so a misnamed requirement doesn't silently pass
+    logWarn("unknown non-boolean requirement key: " + requirement.key, "Requirements.brs")
+    return false
 end function
 function getMinOS(requirement as object, os as float) as boolean
-    if (os >= requirement.value["minVersion"])
-        return true
-    end if
-    return false
+    return os >= requirement.value["minVersion"]
 end function
 function getModel(requirement as object, model as string) as boolean
     for each legacyModel in requirement.value["legacyModels"]


### PR DESCRIPTION
## Summary

Single-file polish PR for `components/utils/Requirements.brs`. Mix of one real safety fix and a handful of shape simplifications. Net **-10 lines**.

## The safety fix — `setAsBool` now fails closed on unknown keys

Before:
```brs
function setAsBool(requirement as object, v as dynamic)
    if (requirement.key = "os")
        return getMinOS(requirement, v)
    else if (requirement.key = "model")
        return getModel(requirement, v)
    end if
    ' implicit invalid return
end function
```

If a future contributor adds a non-boolean requirement (e.g. `"minMemory"`) without extending `setAsBool`, the function returns `invalid`. Upstream in `checkRequirements` that's caught by `if (deviceReady <> invalid)` → coerced back to `true`. **The requirement silently passes.** Fail-open is dangerous depending on what the requirement is gating.

After:
```brs
function setAsBool(requirement as object, v as dynamic) as boolean
    if requirement.key = "os" then return getMinOS(requirement, v)
    if requirement.key = "model" then return getModel(requirement, v)
    ' fail closed on unknown keys so a misnamed requirement doesn't silently pass
    logWarn("unknown non-boolean requirement key: " + requirement.key, "Requirements.brs")
    return false
end function
```

Now: log the unknown key, return false → requirement fails → channel either shows an error or fails to start, instead of silently bypassing.

## Shape simplifications

### `checkRequirements`
Flattened via `continue for` to skip non-required entries early, and converted the two `<> invalid and X` truthy checks on `"required"` and `"showError"` to `= true` (same `hasValue`-PR convention).

```brs
for each requirement in requirements.items()
    if requirement.value = invalid or requirement.value["required"] <> true then continue for
    deviceReady = getRequirement(requirement)
    if deviceReady = invalid
        deviceReady = true
    else if not deviceReady and requirement.value["showError"] = true
        m.scene.message = requirement.key
        exit for
    end if
end for
```

`continue for` is native BrightScript since Roku OS 9.4 — well below this repo's enforced 10.0 floor.

### `getRequirement`
The if/else-if/else chain becomes three early returns:

```brs
function getRequirement(requirement as object) as boolean
    v = m.global[requirement.key]
    if v = invalid then return false
    if type(v) = "roBoolean" then return v
    return setAsBool(requirement, v)
end function
```

### `getMinOS`
The classic "if X then return true else return false" — collapsed to one expression:

```brs
function getMinOS(requirement as object, os as float) as boolean
    return os >= requirement.value["minVersion"]
end function
```

## Not touched

`getModel` has the same shape opportunity but the loop with early return inside doesn't reduce to a one-liner cleanly. Left alone.

## Testing

Visual review only. For the existing four requirements (`internet`, `os`, `model`, `hdcp`), behavior is identical:
- `internet` / `hdcp` → boolean → `getRequirement` returns `v` directly, never hits `setAsBool`
- `os` → float → `setAsBool` → `getMinOS` (now a one-liner, same comparison)
- `model` → string → `setAsBool` → `getModel` (unchanged)

The new fail-closed path is only reached if someone adds a fifth requirement type without extending `setAsBool`.

Sideload smoke test: launch the channel with `setRequirements(true)` enabled in `HomeScene.init()`, then bump `minVersion` in `requirements.json` to `99.0` — should trigger the OS update dialog same as before.